### PR TITLE
Added a projector for omni-directional stereo

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/projection/OmniDirectionalStereoProjector.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/projection/OmniDirectionalStereoProjector.java
@@ -38,10 +38,17 @@ public class OmniDirectionalStereoProjector implements Projector {
   /**
    * The interpupillary distance of the viewer, in meters.
    */
-  private double interpupillaryDistance = 0.069;
+  private static final double interpupillaryDistance = 0.069;
+
+  private final double scale;
 
   public OmniDirectionalStereoProjector(Eye eye) {
     this.eye = eye;
+    if (eye == Eye.LEFT) {
+      scale = -interpupillaryDistance / 2;
+    } else {
+      scale = interpupillaryDistance / 2;
+    }
   }
 
   @Override
@@ -54,12 +61,6 @@ public class OmniDirectionalStereoProjector implements Projector {
     double theta = (x + 0.5) * FastMath.PI - FastMath.PI;
     double phi = FastMath.PI / 2 - (y + 0.5) * FastMath.PI;
 
-    double scale;
-    if (eye == Eye.LEFT) {
-      scale = -interpupillaryDistance / 2;
-    } else {
-      scale = interpupillaryDistance / 2;
-    }
     pos.set(FastMath.cos(theta) * scale, 0, FastMath.sin(theta) * scale);
     direction.set(FastMath.sin(theta) * FastMath.cos(phi), FastMath.sin(phi), -FastMath.cos(theta) * FastMath.cos(phi));
   }

--- a/chunky/src/java/se/llbit/chunky/renderer/projection/OmniDirectionalStereoProjector.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/projection/OmniDirectionalStereoProjector.java
@@ -31,11 +31,6 @@ import java.util.Random;
  */
 public class OmniDirectionalStereoProjector implements Projector {
   /**
-  * The eye that this projector produces rays for.
-  */
-  private final Eye eye;
-
-  /**
    * The interpupillary distance of the viewer, in meters.
    */
   private static final double interpupillaryDistance = 0.069;
@@ -43,7 +38,6 @@ public class OmniDirectionalStereoProjector implements Projector {
   private final double scale;
 
   public OmniDirectionalStereoProjector(Eye eye) {
-    this.eye = eye;
     if (eye == Eye.LEFT) {
       scale = -interpupillaryDistance / 2;
     } else {

--- a/chunky/src/java/se/llbit/chunky/renderer/projection/OmniDirectionalStereoProjector.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/projection/OmniDirectionalStereoProjector.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 Jesper Öqvist <jesper@llbit.se>
+/* Copyright (c) 2016 Chunky contributors
  *
  * This file is part of Chunky.
  *

--- a/chunky/src/java/se/llbit/chunky/renderer/projection/OmniDirectionalStereoProjector.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/projection/OmniDirectionalStereoProjector.java
@@ -23,9 +23,10 @@ import java.util.Random;
 
 /**
  * A projector for Omni-Directional Stereo (ODS) images. x is mapped to yaw, y is mapped to
- * pitch. This projector is like the {@link PanoramicProjector} but can create distinct
- * images for the left and the right eye to create panoramic stereo images that are perfect
- * for viewing on VR devices.
+ * pitch. This projector, unlike the {@link PanoramicProjector}, can create distinct
+ * images for the left and the right eye by slightly displacing the view ray origins based on the
+ * viewing angle to account for the inter-pupillary distance. This allows to create panoramic
+ * stereo images that are perfect for viewing on VR devices.
  *
  * @see <a href="https://developers.google.com/vr/jump/rendering-ods-content.pdf">Rendering Omni‐directional Stereo Content</a>
  */

--- a/chunky/src/java/se/llbit/chunky/renderer/projection/OmniDirectionalStereoProjector.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/projection/OmniDirectionalStereoProjector.java
@@ -23,7 +23,9 @@ import java.util.Random;
 
 /**
  * A projector for Omni-Directional Stereo (ODS) images. x is mapped to yaw, y is mapped to
- * pitch.
+ * pitch. This projector is like the {@link PanoramicProjector} but can create distinct
+ * images for the left and the right eye to create panoramic stereo images that are perfect
+ * for viewing on VR devices.
  *
  * @see <a href="https://developers.google.com/vr/jump/rendering-ods-content.pdf">Rendering Omni‐directional Stereo Content</a>
  */

--- a/chunky/src/java/se/llbit/chunky/renderer/projection/OmniDirectionalStereoProjector.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/projection/OmniDirectionalStereoProjector.java
@@ -1,0 +1,84 @@
+/* Copyright (c) 2016 Jesper Öqvist <jesper@llbit.se>
+ *
+ * This file is part of Chunky.
+ *
+ * Chunky is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chunky is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package se.llbit.chunky.renderer.projection;
+
+import org.apache.commons.math3.util.FastMath;
+import se.llbit.math.Vector3;
+
+import java.util.Random;
+
+/**
+ * A projector for Omni-Directional Stereo (ODS) images. x is mapped to yaw, y is mapped to
+ * pitch.
+ *
+ * @see <a href="https://developers.google.com/vr/jump/rendering-ods-content.pdf">Rendering Omni‐directional Stereo Content</a>
+ */
+public class OmniDirectionalStereoProjector implements Projector {
+  /**
+  * The eye that this projector produces rays for.
+  */
+  private final Eye eye;
+
+  /**
+   * The interpupillary distance of the viewer, in meters.
+   */
+  private double interpupillaryDistance = 0.069;
+
+  public OmniDirectionalStereoProjector(Eye eye) {
+    this.eye = eye;
+  }
+
+  @Override
+  public void apply(double x, double y, Random random, Vector3 pos, Vector3 direction) {
+    apply(x, y, pos, direction);
+  }
+
+  @Override
+  public void apply(double x, double y, Vector3 pos, Vector3 direction) {
+    double theta = (x + 0.5) * FastMath.PI - FastMath.PI;
+    double phi = FastMath.PI / 2 - (y + 0.5) * FastMath.PI;
+
+    double scale;
+    if (eye == Eye.LEFT) {
+      scale = -interpupillaryDistance / 2;
+    } else {
+      scale = interpupillaryDistance / 2;
+    }
+    pos.set(FastMath.cos(theta) * scale, 0, FastMath.sin(theta) * scale);
+    direction.set(FastMath.sin(theta) * FastMath.cos(phi), FastMath.sin(phi), -FastMath.cos(theta) * FastMath.cos(phi));
+  }
+
+  @Override
+  public double getMinRecommendedFoV() {
+    return 180;
+  }
+
+  @Override
+  public double getMaxRecommendedFoV() {
+    return 180;
+  }
+
+  @Override
+  public double getDefaultFoV() {
+    return 180;
+  }
+
+  public enum Eye {
+    LEFT,
+    RIGHT
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/renderer/projection/ProjectionMode.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/projection/ProjectionMode.java
@@ -27,7 +27,9 @@ public enum ProjectionMode {
   FISHEYE("Fisheye"),
   STEREOGRAPHIC("Stereographic"),
   PANORAMIC("Panoramic (equirectangular)"),
-  PANORAMIC_SLOT("Panoramic (slot)");
+  PANORAMIC_SLOT("Panoramic (slot)"),
+  ODS_LEFT("Omni‐directional Stereo (left eye)"),
+  ODS_RIGHT("Omni‐directional Stereo (right eye)");
 
   private final String niceName;
 

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Camera.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Camera.java
@@ -21,6 +21,8 @@ import se.llbit.chunky.renderer.Refreshable;
 import se.llbit.chunky.renderer.projection.ApertureProjector;
 import se.llbit.chunky.renderer.projection.FisheyeProjector;
 import se.llbit.chunky.renderer.projection.ForwardDisplacementProjector;
+import se.llbit.chunky.renderer.projection.OmniDirectionalStereoProjector;
+import se.llbit.chunky.renderer.projection.OmniDirectionalStereoProjector.Eye;
 import se.llbit.chunky.renderer.projection.PanoramicProjector;
 import se.llbit.chunky.renderer.projection.PanoramicSlotProjector;
 import se.llbit.chunky.renderer.projection.ParallelProjector;
@@ -196,6 +198,10 @@ public class Camera implements JSONifiable {
         return applySphericalDoF(new PanoramicProjector(fov));
       case STEREOGRAPHIC:
         return new StereographicProjector(fov);
+      case ODS_LEFT:
+        return new OmniDirectionalStereoProjector(Eye.LEFT);
+      case ODS_RIGHT:
+        return new OmniDirectionalStereoProjector(Eye.RIGHT);
     }
   }
 


### PR DESCRIPTION
This PR adds a new projector for [Omni-directional Stereo][ods-google] pictures and two new projection modes (left and right eye). The resulting two images of a scene can be used to create stereographic 360° VR spheres. :globe_with_meridians:

Requested in #364. I also already signed the CLA. :+1: 

[ods-google]: https://developers.google.com/vr/jump/rendering-ods-content.pdf

Edit: I uploaded a [demo sphere](https://lemaik.github.io/rs-sphere/). Just click on the VR icon on the bottom right of the page. Works great with Google Cardboard.