### PR TITLE
Add Hable (Uncharted 2) and ACES filmic tone mapping

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/Postprocess.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/Postprocess.java
@@ -38,10 +38,14 @@ public enum Postprocess {
     }
   },
   TONEMAP2 {
-    @Override public String toString() { return "ACES filmic tone mapping"; }
+    @Override public String toString() {
+      return "ACES filmic tone mapping";
+    }
   },
   TONEMAP3 {
-    @Override public String toString() { return "Hable tonemapping"; }
+    @Override public String toString() {
+      return "Hable tonemapping";
+    }
   };
 
   public static final Postprocess DEFAULT = GAMMA;

--- a/chunky/src/java/se/llbit/chunky/renderer/Postprocess.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/Postprocess.java
@@ -36,6 +36,12 @@ public enum Postprocess {
     @Override public String toString() {
       return "Tonemap operator 1";
     }
+  },
+  TONEMAP2 {
+    @Override public String toString() { return "ACES filmic tone mapping"; }
+  },
+  TONEMAP3 {
+    @Override public String toString() { return "Hable tonemapping"; }
   };
 
   public static final Postprocess DEFAULT = GAMMA;

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -1946,7 +1946,9 @@ public class Scene implements JsonSerializable, Refreshable {
           float hD = 0.20f;
           float hE = 0.02f;
           float hF = 0.30f;
-          r *= 16; // manually adjust exposure to approx. match other post-processing modes
+          // This adjusts the exposure by a factor of 16 so that the resulting exposure approximately matches the other
+          // post-processing methods. Without this, the image would be very dark.
+          r *= 16;
           g *= 16;
           b *= 16;
           r = ((r * (hA * r + hC * hB) + hD * hE) / (r * (hA * r + hB) + hD * hF)) - hE / hF;

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -1927,6 +1927,37 @@ public class Scene implements JsonSerializable, Refreshable {
           b = QuickMath.max(0, b - 0.004);
           b = (b * (6.2 * b + .5)) / (b * (6.2 * b + 1.7) + 0.06);
           break;
+        case TONEMAP2:
+          // https://knarkowicz.wordpress.com/2016/01/06/aces-filmic-tone-mapping-curve/
+          float aces_a = 2.51f;
+          float aces_b = 0.03f;
+          float aces_c = 2.43f;
+          float aces_d = 0.59f;
+          float aces_e = 0.14f;
+          r = QuickMath.max(QuickMath.min((r * (aces_a * r + aces_b)) / (r * (aces_c * r + aces_d) + aces_e), 1), 0);
+          g = QuickMath.max(QuickMath.min((g * (aces_a * g + aces_b)) / (r * (aces_c * g + aces_d) + aces_e), 1), 0);
+          b = QuickMath.max(QuickMath.min((b * (aces_a * b + aces_b)) / (r * (aces_c * b + aces_d) + aces_e), 1), 0);
+          break;
+        case TONEMAP3:
+          // http://filmicgames.com/archives/75
+          float hA = 0.15f;
+          float hB = 0.50f;
+          float hC = 0.10f;
+          float hD = 0.20f;
+          float hE = 0.02f;
+          float hF = 0.30f;
+          r *= 16; // manually adjust exposure to approx. match other post-processing modes
+          g *= 16;
+          b *= 16;
+          r = ((r * (hA * r + hC * hB) + hD * hE) / (r * (hA * r + hB) + hD * hF)) - hE / hF;
+          g = ((g * (hA * g + hC * hB) + hD * hE) / (g * (hA * g + hB) + hD * hF)) - hE / hF;
+          b = ((b * (hA * b + hC * hB) + hD * hE) / (b * (hA * b + hB) + hD * hF)) - hE / hF;
+          float hW = 11.2f;
+          float whiteScale = 1.0f / (((hW * (hA * hW + hC * hB) + hD * hE) / (hW * (hA * hW + hB) + hD * hF)) - hE / hF);
+          r *= whiteScale;
+          g *= whiteScale;
+          b *= whiteScale;
+          break;
         case GAMMA:
           r = FastMath.pow(r, 1 / DEFAULT_GAMMA);
           g = FastMath.pow(g, 1 / DEFAULT_GAMMA);


### PR DESCRIPTION
(I hit the enter key before writing a description, sorry!)

I know that there are plugins, but these two new tone mappings seem to be a useful addition to the core, as there already is the _tonemapping operator 1_.

Sometimes, the scene looks pretty grayish with gamma correction and even with the existing tone mapping operator

Gamma correction:
![markus-100-gamma](https://cloud.githubusercontent.com/assets/5544859/23102295/0c267d42-f6a7-11e6-9333-d99d21902b5f.png)

Tone mapping op. 1:
![markus-100-tonemap1](https://cloud.githubusercontent.com/assets/5544859/23102302/1b7ad4d2-f6a7-11e6-950c-bec025bcbf08.png)

Hable's tonemapping looks really great, it preserves some colors better than the above modes:
![markus-100-hable](https://cloud.githubusercontent.com/assets/5544859/23102311/39304cbe-f6a7-11e6-80df-d44170763aa8.png)

And while we're at it, the ACES tone mapping curve aims to give the scenes a more filmic look, although it requires careful adjusting of the sunlight and exposure (my scene looks a little too blueish, but the contrast and color intensity is much better):
![markus-100-aces](https://cloud.githubusercontent.com/assets/5544859/23102324/7ed8d3bc-f6a7-11e6-81a9-de5c1d842f6e.png)
By the way, ACES [is the default tonemap in Unreal Engine 4](https://docs.unrealengine.com/latest/INT/Support/Builds/ReleaseNotes/2015/4_8/).