### PR TITLE
World chooser improvements (worlds list: resizing, asynchronous loading)

### DIFF
--- a/chunky/src/res/se/llbit/chunky/ui/WorldChooser.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/WorldChooser.fxml
@@ -11,7 +11,7 @@
 <VBox maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" spacing="10.0" xmlns="http://javafx.com/javafx/8.0.40" xmlns:fx="http://javafx.com/fxml/1" fx:controller="se.llbit.chunky.ui.WorldChooserController">
    <children>
       <Label text="Select world to load:" />
-      <TableView fx:id="worldTbl" prefHeight="200.0" prefWidth="200.0">
+      <TableView fx:id="worldTbl" minHeight="-Infinity" minWidth="-Infinity" prefHeight="200.0" prefWidth="433.0" VBox.vgrow="ALWAYS">
         <columns>
           <TableColumn fx:id="worldNameCol" maxWidth="1.7976931348623157E308" minWidth="-1.0" prefWidth="174.0" text="World name" />
           <TableColumn fx:id="worldDirCol" minWidth="-1.0" prefWidth="151.0" text="Directory" />

--- a/chunky/src/res/se/llbit/chunky/ui/WorldChooser.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/WorldChooser.fxml
@@ -10,7 +10,7 @@
 
 <VBox maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" spacing="10.0" xmlns="http://javafx.com/javafx/8.0.40" xmlns:fx="http://javafx.com/fxml/1" fx:controller="se.llbit.chunky.ui.WorldChooserController">
    <children>
-      <Label text="Select world to load:" />
+      <Label fx:id="statusLabel" text="Select world to load:" />
       <TableView fx:id="worldTbl" minHeight="-Infinity" minWidth="-Infinity" prefHeight="200.0" prefWidth="433.0" VBox.vgrow="ALWAYS">
         <columns>
           <TableColumn fx:id="worldNameCol" maxWidth="1.7976931348623157E308" minWidth="-1.0" prefWidth="174.0" text="World name" />


### PR DESCRIPTION
## Vertical resizing of worlds list
Before:
![2017-07-10_18-32-55](https://user-images.githubusercontent.com/1076914/28026342-66106424-659e-11e7-83e4-79aa40bb73d1.png)

After:
![2017-07-10_15-16-43](https://user-images.githubusercontent.com/1076914/28026364-752fcddc-659e-11e7-973e-d83a0075ef20.png)
c84b373

## Asynchronous loading of worlds list
If you have many worlds, after clicking "Change World" button you may experience a slight delay. Now it works a little differently. At the moment loading the list of worlds, window looks like this:

![2017-07-10_15-19-16](https://user-images.githubusercontent.com/1076914/28026398-98b8bf48-659e-11e7-860e-bdc051a72b64.png)

That improvement minimizing delay between button click and window showing.
3b3c5f4

