### PR TITLE
Fix loading of symlinked plugins

### DIFF
--- a/chunky/src/java/se/llbit/chunky/main/Chunky.java
+++ b/chunky/src/java/se/llbit/chunky/main/Chunky.java
@@ -241,15 +241,19 @@ public class Chunky {
       String jarName = value.asString("");
       if (!jarName.isEmpty()) {
         Log.info("Loading plugin: " + value);
-        ChunkyPlugin.load(pluginsPath.resolve(jarName).toFile(), (plugin, manifest) -> {
-          try {
-            plugin.attach(this);
-          } catch (Throwable t) {
-            Log.error("Plugin " + jarName + " failed to load.", t);
-          }
-          Log.infof("Plugin loaded: %s %s", manifest.get("name").asString(""),
-              manifest.get("version").asString(""));
-        });
+        try {
+          ChunkyPlugin.load(pluginsPath.resolve(jarName).toRealPath().toFile(), (plugin, manifest) -> {
+            try {
+              plugin.attach(this);
+            } catch (Throwable t) {
+              Log.error("Plugin " + jarName + " failed to load.", t);
+            }
+            Log.infof("Plugin loaded: %s %s", manifest.get("name").asString(""),
+                manifest.get("version").asString(""));
+          });
+        } catch (Throwable t) {
+          Log.error("Plugin " + jarName + " failed to load.", t);
+        }
       }
     }
   }


### PR DESCRIPTION
ZipFileSystem doesn't work with symlinks, so they need to be resolved first. Using symlinks is pretty useful during plugin development.