### PR TITLE
Patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Chunky is a Minecraft rendering tool that uses Path Tracing to create realistic 
 
 ## Quick start guide
 
-_Prerequisites:_ Chunky requires **Java 8**. It is recommended to have the **64-bit** version if you have a 64-bit operating system (you most likely do). If you haven't installed it yet, [download Windows Offline (64-bit) from here][13].
+_Prerequisites:_ Chunky requires **Java 8**. It is recommended to have the **64-bit** version if you have a 64-bit operating system (you most likely do). If you are running Windows, you can download [Windows Offline (64-bit) from here][13].
 
 1. Download [the Chunky Launcher][12] and open it
 2. Install the latest version of Chunky by clicking on _Check for Updates_

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Chunky is a Minecraft rendering tool that uses Path Tracing to create realistic 
 
 ## Quick start guide
 
-_Prerequisites:_ Chunky requires **Java 8**. It is recommended to have the **64-bit** version if you have a 64-bit operating system (you most likely do). If you are running Windows, you can [download Windows Offline (64-bit) from here][13].
+_Prerequisites:_ Chunky requires **Java 8**. It is recommended to have the **64-bit** version if you have a 64-bit operating system (you most likely do). If you haven't installed Java, you can [download it from here][13].
 
 1. Download [the Chunky Launcher][12] and open it
 2. Install the latest version of Chunky by clicking on _Check for Updates_

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Chunky is a Minecraft rendering tool that uses Path Tracing to create realistic 
 
 ## Quick start guide
 
-_Prerequisites:_ Chunky requires Java 8, and it is recommended to install the 64-bit version if you have a 64-bit operating system (you most likely do). If you haven't installed it yet, [get it from here][13].
+_Prerequisites:_ Chunky requires Java 8. It is recommended to install the 64-bit version if you have a 64-bit operating system (you most likely do). If you haven't installed it yet, [get Oracle Java 8 from here][13]. Should you wish to use OpenJDK you will need OpenJFX. [Windows OpenJFX Binaries][15]
 
 1. Download [the Chunky Launcher][12] and open it
 2. Install the latest version of Chunky by clicking on _Check for Updates_
@@ -198,3 +198,4 @@ See the file `licenses/commons-math.txt` for the copyright notices.
 [12]: http://chunkyupdate.lemaik.de/ChunkyLauncher.jar
 [13]: https://www.java.com/en/download/manual.jsp
 [14]: https://github.com/llbit/chunky/issues/553
+[15]: https://github.com/SkyLandTW/OpenJFX-binary-windows

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Chunky is a Minecraft rendering tool that uses Path Tracing to create realistic 
 
 ## Quick start guide
 
-_Prerequisites:_ Chunky requires Java 8. It is recommended to have the 64-bit version if you have a 64-bit operating system (you most likely do). If you haven't installed it yet, [get Oracle Java 8 from here][13].
+_Prerequisites:_ Chunky requires **Java 8**. It is recommended to have the **64-bit** version if you have a 64-bit operating system (you most likely do). If you haven't installed it yet, [get Oracle Java 8 from here][13].
 
 1. Download [the Chunky Launcher][12] and open it
 2. Install the latest version of Chunky by clicking on _Check for Updates_

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Chunky is a Minecraft rendering tool that uses Path Tracing to create realistic 
 
 ## Quick start guide
 
-_Prerequisites:_ Chunky requires Java 8. If you haven't installed it yet, [get it from here][13]. Make sure that you have installed the 64-bit version if you have a 64-bit operating system (you most likely do).
+_Prerequisites:_ Chunky requires Java 8 and it is recommended to install the 64-bit version if you have a 64-bit operating system (you most likely do). If you haven't installed it yet, [get it from here][13].
 
 1. Download [the Chunky Launcher][12] and open it
 2. Install the latest version of Chunky by clicking on _Check for Updates_

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Chunky is a Minecraft rendering tool that uses Path Tracing to create realistic images of your Minecraft worlds.
 
-[Discord server](https://discord.gg/VqcHpsF) ·
+[Discord server][15] ·
 [Documentation][8] ·
 [Troubleshooting][2] ·
 [Subreddit][3]
@@ -15,7 +15,7 @@ Chunky is a Minecraft rendering tool that uses Path Tracing to create realistic 
 
 ## Quick start guide
 
-_Prerequisites:_ Chunky requires Java 8. It is recommended to install the 64-bit version if you have a 64-bit operating system (you most likely do). If you haven't installed it yet, [get Oracle Java 8 from here][13]. Should you wish to use OpenJDK you will need OpenJFX. [Windows OpenJFX Binaries][15]
+_Prerequisites:_ Chunky requires Java 8. It is recommended to install the 64-bit version if you have a 64-bit operating system (you most likely do). If you haven't installed it yet, [get Oracle Java 8 from here][13].
 
 1. Download [the Chunky Launcher][12] and open it
 2. Install the latest version of Chunky by clicking on _Check for Updates_
@@ -198,4 +198,4 @@ See the file `licenses/commons-math.txt` for the copyright notices.
 [12]: http://chunkyupdate.lemaik.de/ChunkyLauncher.jar
 [13]: https://www.java.com/en/download/manual.jsp
 [14]: https://github.com/llbit/chunky/issues/553
-[15]: https://github.com/SkyLandTW/OpenJFX-binary-windows
+[15]: https://discord.gg/VqcHpsF

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Chunky is a Minecraft rendering tool that uses Path Tracing to create realistic 
 
 ## Quick start guide
 
-_Prerequisites:_ Chunky requires **Java 8**. It is recommended to have the **64-bit** version if you have a 64-bit operating system (you most likely do). If you haven't installed it yet, [get Oracle Java 8 from here][13].
+_Prerequisites:_ Chunky requires **Java 8**. It is recommended to have the **64-bit** version if you have a 64-bit operating system (you most likely do). If you haven't installed it yet, [download Windows Offline (64-bit) from here][13].
 
 1. Download [the Chunky Launcher][12] and open it
 2. Install the latest version of Chunky by clicking on _Check for Updates_

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Chunky is a Minecraft rendering tool that uses Path Tracing to create realistic 
 
 ## Quick start guide
 
-_Prerequisites:_ Chunky requires Java 8. It is recommended to install the 64-bit version if you have a 64-bit operating system (you most likely do). If you haven't installed it yet, [get Oracle Java 8 from here][13].
+_Prerequisites:_ Chunky requires Java 8. It is recommended to have the 64-bit version if you have a 64-bit operating system (you most likely do). If you haven't installed it yet, [get Oracle Java 8 from here][13].
 
 1. Download [the Chunky Launcher][12] and open it
 2. Install the latest version of Chunky by clicking on _Check for Updates_

--- a/README.md
+++ b/README.md
@@ -196,5 +196,5 @@ See the file `licenses/commons-math.txt` for the copyright notices.
 [10]: https://github.com/leMaik/chunky-denoiser
 [11]: https://chunky.llbit.se/skymaps.html
 [12]: http://chunkyupdate.lemaik.de/ChunkyLauncher.jar
-[13]: https://java.com/download/
+[13]: https://www.java.com/en/download/manual.jsp
 [14]: https://github.com/llbit/chunky/issues/553

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Chunky is a Minecraft rendering tool that uses Path Tracing to create realistic 
 
 ## Quick start guide
 
-_Prerequisites:_ Chunky requires **Java 8**. It is recommended to have the **64-bit** version if you have a 64-bit operating system (you most likely do). If you are running Windows, you can download [Windows Offline (64-bit) from here][13].
+_Prerequisites:_ Chunky requires **Java 8**. It is recommended to have the **64-bit** version if you have a 64-bit operating system (you most likely do). If you are running Windows, you can [download Windows Offline (64-bit) from here][13].
 
 1. Download [the Chunky Launcher][12] and open it
 2. Install the latest version of Chunky by clicking on _Check for Updates_

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Chunky is a Minecraft rendering tool that uses Path Tracing to create realistic 
 
 ## Quick start guide
 
-_Prerequisites:_ Chunky requires Java 8 and it is recommended to install the 64-bit version if you have a 64-bit operating system (you most likely do). If you haven't installed it yet, [get it from here][13].
+_Prerequisites:_ Chunky requires Java 8, and it is recommended to install the 64-bit version if you have a 64-bit operating system (you most likely do). If you haven't installed it yet, [get it from here][13].
 
 1. Download [the Chunky Launcher][12] and open it
 2. Install the latest version of Chunky by clicking on _Check for Updates_


### PR DESCRIPTION
Switched Java download to manual to avoid Java.com automatically giving out 32-bit Java.

Re-ordered sentences such that 64-bit is mentioned prior to download link