### PR TITLE
Support loading chunks that were saved with 20w17a.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/MinecraftBlockProvider.java
+++ b/chunky/src/java/se/llbit/chunky/block/MinecraftBlockProvider.java
@@ -1582,9 +1582,10 @@ public class MinecraftBlockProvider implements BlockProvider {
         return log(tag, Texture.crimsonStem, Texture.crimsonStemTop);
       case "stripped_crimson_stem":
         return log(tag, Texture.strippedCrimsonStem, Texture.strippedCrimsonStemTop);
-      case "soul_fire_lantern":
+      case "soul_fire_lantern": // 20w06a - 20w16a
+      case "soul_lantern": // since 20w17a
         return new Lantern(
-            "soul_fire_lantern",
+            name,
             Texture.soulFireLantern,
             tag.get("Properties").get("hanging").stringValue("false").equals("true"));
       case "twisting_vines":
@@ -1595,9 +1596,11 @@ public class MinecraftBlockProvider implements BlockProvider {
         return new SpriteBlock("weeping_vines", Texture.weepingVines);
       case "weeping_vines_plant":
         return new SpriteBlock("weeping_vines_plant", Texture.weepingVinesPlant);
-      case "soul_fire_torch":
+      case "soul_fire_torch": // 20w06a - 20w16a
+      case "soul_torch": // since 20w17a
         return new Torch(name, Texture.soulFireTorch);
-      case "soul_fire_wall_torch":
+      case "soul_fire_wall_torch": // 20w06a - 20w16a
+      case "soul_wall_torch": // since 20w17a
         return wallTorch(tag, Texture.soulFireTorch);
       case "respawn_anchor":
         return new RespawnAnchor(

--- a/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
+++ b/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
@@ -211,13 +211,22 @@ public class BlockPalette {
     materialProperties.put("minecraft:shroomlight", block -> {
       block.emittance = 1.0f;
     });
-    materialProperties.put("minecraft:soul_fire_lantern", block -> {
+    materialProperties.put("minecraft:soul_fire_lantern", block -> { // MC 20w06a-20w16a
       block.emittance = 0.6f;
     });
-    materialProperties.put("minecraft:soul_fire_torch", block -> {
+    materialProperties.put("minecraft:soul_lantern", block -> { // MC >= 20w17a
+      block.emittance = 0.6f;
+    });
+    materialProperties.put("minecraft:soul_fire_torch", block -> { // MC 20w06a-20w16a
       block.emittance = 35.0f;
     });
-    materialProperties.put("minecraft:soul_fire_wall_torch", block -> {
+    materialProperties.put("minecraft:soul_torch", block -> { // MC >= 20w17a
+      block.emittance = 35.0f;
+    });
+    materialProperties.put("minecraft:soul_fire_wall_torch", block -> { // MC 20w06a-20w16a
+      block.emittance = 35.0f;
+    });
+    materialProperties.put("minecraft:soul_wall_torch", block -> { // MC >= 20w17a
       block.emittance = 35.0f;
     });
     materialProperties.put("minecraft:soul_fire", block -> {

--- a/chunky/src/java/se/llbit/chunky/world/Chunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/Chunk.java
@@ -269,13 +269,17 @@ public class Chunk {
           Tag blockStates = section.get("BlockStates");
 
           if (blockStates.isLongArray(dataSize)) {
+            // since 20w17a, block states are aligned to 64-bit boundaries, so there are 64 % bpb
+            // unused bits per block state; if so, the array is longer than the expected data size
+            boolean isAligned = blockStates.longArray().length > dataSize;
+
             int[] subpalette = new int[palette.size()];
             int paletteIndex = 0;
             for (Tag item : palette.asList()) {
               subpalette[paletteIndex] = blockPalette.put(item);
               paletteIndex += 1;
             }
-            BitBuffer buffer = new BitBuffer(blockStates.longArray(), bpb);
+            BitBuffer buffer = new BitBuffer(blockStates.longArray(), bpb, isAligned);
             int offset = SECTION_BYTES * yOffset;
             for (int i = 0; i < SECTION_BYTES; ++i) {
               int b0 = buffer.read();

--- a/chunky/src/java/se/llbit/util/BitBuffer.java
+++ b/chunky/src/java/se/llbit/util/BitBuffer.java
@@ -41,7 +41,6 @@ public class BitBuffer {
     this.stride = stride;
     this.aligned = aligned;
     mask = (1 << stride) - 1;
-    shift = 0;
   }
 
   public int read() {
@@ -58,20 +57,15 @@ public class BitBuffer {
         res = (int) (data[offset] >>> shift) & mask;
         offset += 1;
         shift = 0;
-      } else {
-        if (aligned) {
-          res = (int) (data[offset] >>> shift) & mask;
-          shift += stride;
-        } else {
-          // High bits:
-          int bits = 64 - shift;
-          res = (int) (data[offset] >>> shift);
-          offset += 1;
-          int rem = stride - bits;
-          // Low bits:
-          res |= ((int) data[offset] & ((1 << rem) - 1)) << bits;
-          shift = rem;
-        }
+      } else { // only reached if aligned is false
+        // High bits:
+        int bits = 64 - shift;
+        res = (int) (data[offset] >>> shift);
+        offset += 1;
+        int rem = stride - bits;
+        // Low bits:
+        res |= ((int) data[offset] & ((1 << rem) - 1)) << bits;
+        shift = rem;
       }
     }
 


### PR DESCRIPTION
As of 20w17a, block states are aligned to 8-byte boundaries. This PR fixes chunk loading (but stays compatible with 1.13+ chunks).