### PR TITLE
Fix library downloads

### DIFF
--- a/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
+++ b/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
@@ -49,7 +49,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class ChunkyLauncher {
 
-  public static final String LAUNCHER_VERSION = "v1.11.3";
+  public static final String LAUNCHER_VERSION = "v1.11.4";
 
   /**
    * Print a launch error message to the console.

--- a/launcher/src/se/llbit/chunky/launcher/ui/UpdateDialogController.java
+++ b/launcher/src/se/llbit/chunky/launcher/ui/UpdateDialogController.java
@@ -289,7 +289,7 @@ public final class UpdateDialogController implements Initializable {
       }
       // Using the library URL failed.
       // Try downloading the library from the default update site.
-      String defaultUrl = launcher.settings.updateSite + "lib/" + lib.name;
+      String defaultUrl = launcher.settings.getResourceUrl("lib/" + lib.name);
       if (result != DownloadStatus.SUCCESS) {
         result = ChunkyLauncher.tryDownload(libDir, lib, defaultUrl);
       }

--- a/lib/src/se/llbit/chunky/launcher/LauncherSettings.java
+++ b/lib/src/se/llbit/chunky/launcher/LauncherSettings.java
@@ -25,7 +25,7 @@ import java.io.File;
 public class LauncherSettings {
   private static final int DEFAULT_MEMORY_LIMIT = 1024;
   public static final String LAUNCHER_SETTINGS_FILE = "chunky-launcher.json";
-  public static final String DEFAULT_UPDATE_SITE = "http://chunkyupdate.lemaik.de/";
+  public static final String DEFAULT_UPDATE_SITE = "https://chunkyupdate.lemaik.de";
 
   public String javaDir = "";
   public int memoryLimit = DEFAULT_MEMORY_LIMIT;


### PR DESCRIPTION
This fixes issues with failed library downloads if the update site doesn't have trailing slash.