### PR TITLE
Restore previously removed PngFileWriter and TiffFileWriter constructors

### DIFF
--- a/chunky/src/java/se/llbit/png/PngFileWriter.java
+++ b/chunky/src/java/se/llbit/png/PngFileWriter.java
@@ -16,6 +16,8 @@
  */
 package se.llbit.png;
 
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.OutputStream;
 import se.llbit.util.TaskTracker;
 
@@ -43,6 +45,13 @@ public class PngFileWriter implements AutoCloseable {
   public PngFileWriter(OutputStream out) throws IOException {
     this.out = new DataOutputStream(out);
     this.out.writeLong(PNG_SIGNATURE);
+  }
+
+  /**
+   * @throws IOException
+   */
+  public PngFileWriter(File file) throws IOException {
+    this(new FileOutputStream(file));
   }
 
   /**

--- a/chunky/src/java/se/llbit/tiff/TiffFileWriter.java
+++ b/chunky/src/java/se/llbit/tiff/TiffFileWriter.java
@@ -16,6 +16,8 @@
  */
 package se.llbit.tiff;
 
+import java.io.File;
+import java.io.FileOutputStream;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.util.TaskTracker;
 
@@ -45,6 +47,13 @@ public class TiffFileWriter implements AutoCloseable {
     out.write(0x4D);
     out.write(0x00);
     out.write(0x2A);
+  }
+
+  /**
+   * @throws IOException
+   */
+  public TiffFileWriter(File file) throws IOException {
+    this(new FileOutputStream(file));
   }
 
   /**


### PR DESCRIPTION
Regression introduced by #583, breaks plugins that require the constructors (e.g. the denoiser plugin).