### PR TITLE
Add support for netherite armor

### DIFF
--- a/chunky/src/java/se/llbit/chunky/entity/PlayerEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/PlayerEntity.java
@@ -645,6 +645,14 @@ public class PlayerEntity extends Entity implements Poseable, Geared {
         case "diamond_leggings":
           loader = simpleTexture("models/armor/diamond_layer_2", texture);
           break;
+        case "netherite_boots":
+        case "netherite_helmet":
+        case "netherite_chestplate":
+          loader = simpleTexture("models/armor/netherite_layer_1", texture);
+          break;
+        case "netherite_leggings":
+          loader = simpleTexture("models/armor/netherite_layer_2", texture);
+          break;
         default:
           Log.warnf("Unknown item ID: %s%n", id);
       }


### PR DESCRIPTION
Fixes part of #595. I couldn't for the life of me get Elytra to work. The values to add a model don't make any sense at all. I got Netherite Armor working, though.

![default_2020-05-31_02-14-23-100](https://user-images.githubusercontent.com/30638248/83347077-e4eb6a80-a2e7-11ea-9fc9-e6ab30725f98.png)
