### PR TITLE
New octree implementation

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -969,9 +969,6 @@ public class Scene implements JsonSerializable, Refreshable {
     buildBvh();
     buildActorBvh();
     Log.info(String.format("Loaded %d chunks", numChunks));
-
-    worldOctree.pack();
-    waterOctree.pack();
   }
 
   private void buildBvh() {
@@ -1757,8 +1754,6 @@ public class Scene implements JsonSerializable, Refreshable {
         camera.setWorldSize(1 << worldOctree.getDepth());
         buildBvh();
         buildActorBvh();
-        worldOctree.pack();
-        waterOctree.pack();
         return true;
       } catch (IOException e) {
         Log.error("Failed to load chunk data!", e);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -975,6 +975,9 @@ public class Scene implements JsonSerializable, Refreshable {
     buildBvh();
     buildActorBvh();
     Log.info(String.format("Loaded %d chunks", numChunks));
+
+    worldOctree.pack();
+    waterOctree.pack();
   }
 
   private void buildBvh() {
@@ -1752,6 +1755,8 @@ public class Scene implements JsonSerializable, Refreshable {
         camera.setWorldSize(1 << worldOctree.getDepth());
         buildBvh();
         buildActorBvh();
+        worldOctree.pack();
+        waterOctree.pack();
         return true;
       } catch (IOException e) {
         Log.error("Failed to load chunk data!", e);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -971,7 +971,7 @@ public class Scene implements JsonSerializable, Refreshable {
     }
 
     chunks = loadedChunks;
-    camera.setWorldSize(1 << worldOctree.depth);
+    camera.setWorldSize(1 << worldOctree.getDepth());
     buildBvh();
     buildActorBvh();
     Log.info(String.format("Loaded %d chunks", numChunks));
@@ -1749,7 +1749,7 @@ public class Scene implements JsonSerializable, Refreshable {
         task.update(2);
         Log.info("Octree loaded");
         calculateOctreeOrigin(chunks);
-        camera.setWorldSize(1 << worldOctree.depth);
+        camera.setWorldSize(1 << worldOctree.getDepth());
         buildBvh();
         buildActorBvh();
         return true;

--- a/chunky/src/java/se/llbit/chunky/resources/OctreeFileFormat.java
+++ b/chunky/src/java/se/llbit/chunky/resources/OctreeFileFormat.java
@@ -32,8 +32,9 @@ public class OctreeFileFormat {
    * Load octrees and grass/foliage textures from a file.
    *
    * @param in input stream for the file to load the scene from.
+   * @param forceNodeBased Forces the octrees to be loaded as NodeBasedOctree
    */
-  public static OctreeData load(DataInputStream in) throws IOException {
+  public static OctreeData load(DataInputStream in, boolean forceNodeBased) throws IOException {
     int version = in.readInt();
     if (version != OCTREE_VERSION) {
       throw new IOException(String.format(
@@ -42,11 +43,20 @@ public class OctreeFileFormat {
     }
     OctreeData data = new OctreeData();
     data.palette = BlockPalette.read(in);
-    data.worldTree = Octree.load(in);
-    data.waterTree = Octree.load(in);
+    data.worldTree = Octree.load(in, forceNodeBased);
+    data.waterTree = Octree.load(in, forceNodeBased);
     data.grassColors = WorldTexture.load(in);
     data.foliageColors = WorldTexture.load(in);
     return data;
+  }
+
+  /**
+   * Load octrees and grass/foliage textures from a file.
+   *
+   * @param in input stream for the file to load the scene from.
+   */
+  public static OctreeData load(DataInputStream in) throws IOException {
+    return load(in, false);
   }
 
   /**

--- a/chunky/src/java/se/llbit/math/NodeBasedOctree.java
+++ b/chunky/src/java/se/llbit/math/NodeBasedOctree.java
@@ -1,0 +1,492 @@
+package se.llbit.math;
+
+import org.apache.commons.math3.util.FastMath;
+import se.llbit.chunky.block.Air;
+import se.llbit.chunky.block.Block;
+import se.llbit.chunky.block.UnknownBlock;
+import se.llbit.chunky.block.Water;
+import se.llbit.chunky.chunk.BlockPalette;
+import se.llbit.chunky.model.TexturedBlockModel;
+import se.llbit.chunky.model.WaterModel;
+import se.llbit.chunky.renderer.scene.Scene;
+import se.llbit.chunky.world.Material;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import static se.llbit.math.Octree.BRANCH_NODE;
+
+/**
+ * This is the classic node-based implementation of an octree
+ */
+public class NodeBasedOctree implements Octree.OctreeImplementation {
+  /**
+   * Recursive depth of the octree
+   */
+  public final int depth;
+
+  /**
+   * Root node
+   */
+  public final Octree.Node root;
+
+  private final Octree.Node[] parents;
+  private final Octree.Node[] cache;
+  private int cx = 0;
+  private int cy = 0;
+  private int cz = 0;
+  private int cacheLevel;
+
+  public NodeBasedOctree(int octreeDepth, Octree.Node node) {
+    depth = octreeDepth;
+    root = node;
+    parents = new Octree.Node[depth];
+    cache = new Octree.Node[depth + 1];
+    cache[depth] = root;
+    cacheLevel = depth;
+  }
+
+  @Override
+  public void set(int type, int x, int y, int z) {
+    set(new Octree.Node(type), x, y, z);
+  }
+
+  @Override
+  public void set(Octree.Node data, int x, int y, int z) {
+    Octree.Node node = root;
+    int parentLevel = depth - 1;
+    int position = 0;
+    for (int i = depth - 1; i >= 0; --i) {
+      parents[i] = node;
+
+      if (node.equals(data)) {
+        return;
+      } else if (node.children == null) {
+        node.subdivide();
+        parentLevel = i;
+      }
+
+      int xbit = 1 & (x >> i);
+      int ybit = 1 & (y >> i);
+      int zbit = 1 & (z >> i);
+      position = (xbit << 2) | (ybit << 1) | zbit;
+      node = node.children[position];
+
+    }
+    parents[0].children[position] = data;
+
+    // Merge nodes where all children have been set to the same type.
+    for (int i = 0; i <= parentLevel; ++i) {
+      Octree.Node parent = parents[i];
+
+      boolean allSame = true;
+      for (Octree.Node child : parent.children) {
+        if (!child.equals(node)) {
+          allSame = false;
+          break;
+        }
+      }
+
+      if (allSame) {
+        parent.merge(node.type);
+        cacheLevel = FastMath.max(i, cacheLevel);
+      } else {
+        break;
+      }
+    }
+  }
+
+  @Override
+  public Octree.Node get(int x, int y, int z) {
+    while (cacheLevel < depth && ((x >>> cacheLevel) != cx ||
+            (y >>> cacheLevel) != cy || (z >>> cacheLevel) != cz))
+      cacheLevel += 1;
+
+    Octree.Node node;
+    while (true) {
+      node = cache[cacheLevel];
+      if (node.type != BRANCH_NODE) {
+        break;
+      }
+      cacheLevel -= 1;
+      cx = x >>> cacheLevel;
+      cy = y >>> cacheLevel;
+      cz = z >>> cacheLevel;
+      cache[cacheLevel] =
+              cache[cacheLevel + 1].children[((cx & 1) << 2) | ((cy & 1) << 1) | (cz & 1)];
+    }
+    return node;
+  }
+
+  @Override
+  public Material getMaterial(int x, int y, int z, BlockPalette palette) {
+    Octree.Node node = get(x, y, z);
+    if (node.type == BRANCH_NODE) {
+      return UnknownBlock.UNKNOWN;
+    }
+    return palette.get(node.type);
+  }
+
+  @Override
+  public void store(DataOutputStream out) throws IOException {
+    out.writeInt(depth);
+    root.store(out);
+  }
+
+  @Override
+  public boolean isInside(Vector3 o) {
+    int x = (int) QuickMath.floor(o.x);
+    int y = (int) QuickMath.floor(o.y);
+    int z = (int) QuickMath.floor(o.z);
+
+    int lx = x >>> depth;
+    int ly = y >>> depth;
+    int lz = z >>> depth;
+
+    return lx == 0 && ly == 0 && lz == 0;
+  }
+
+  @Override
+  public boolean enterBlock(Scene scene, Ray ray, BlockPalette palette) {
+    int level;
+    Octree.Node node;
+    boolean first = true;
+
+    int lx, ly, lz;
+    int x, y, z;
+    int nx = 0, ny = 0, nz = 0;
+    double tNear = Double.POSITIVE_INFINITY;
+    double t;
+    Vector3 d = ray.d;
+
+    while (true) {
+
+      // Add small offset past the intersection to avoid
+      // recursion to the same octree node!
+      x = (int) QuickMath.floor(ray.o.x + d.x * Ray.OFFSET);
+      y = (int) QuickMath.floor(ray.o.y + d.y * Ray.OFFSET);
+      z = (int) QuickMath.floor(ray.o.z + d.z * Ray.OFFSET);
+
+      node = root;
+      level = depth;
+      lx = x >>> level;
+      ly = y >>> level;
+      lz = z >>> level;
+
+      if (lx != 0 || ly != 0 || lz != 0) {
+
+        // ray origin is outside octree!
+
+        // only check octree intersection if this is the first iteration
+        if (first) {
+          // test if it is entering the octree
+          t = -ray.o.x / d.x;
+          if (t > Ray.EPSILON) {
+            tNear = t;
+            nx = 1;
+            ny = nz = 0;
+          }
+          t = ((1 << level) - ray.o.x) / d.x;
+          if (t < tNear && t > Ray.EPSILON) {
+            tNear = t;
+            nx = -1;
+            ny = nz = 0;
+          }
+          t = -ray.o.y / d.y;
+          if (t < tNear && t > Ray.EPSILON) {
+            tNear = t;
+            ny = 1;
+            nx = nz = 0;
+          }
+          t = ((1 << level) - ray.o.y) / d.y;
+          if (t < tNear && t > Ray.EPSILON) {
+            tNear = t;
+            ny = -1;
+            nx = nz = 0;
+          }
+          t = -ray.o.z / d.z;
+          if (t < tNear && t > Ray.EPSILON) {
+            tNear = t;
+            nz = 1;
+            nx = ny = 0;
+          }
+          t = ((1 << level) - ray.o.z) / d.z;
+          if (t < tNear && t > Ray.EPSILON) {
+            tNear = t;
+            nz = -1;
+            nx = ny = 0;
+          }
+
+          if (tNear < Double.MAX_VALUE) {
+            ray.o.scaleAdd(tNear, d);
+            ray.n.set(nx, ny, nz);
+            ray.distance += tNear;
+            tNear = Double.POSITIVE_INFINITY;
+            continue;
+          } else {
+            return false;// outside of octree!
+          }
+        } else {
+          return false;// outside of octree!
+        }
+      }
+
+      first = false;
+
+      while (node.type == BRANCH_NODE) {
+        level -= 1;
+        lx = x >>> level;
+        ly = y >>> level;
+        lz = z >>> level;
+        node = node.children[((lx & 1) << 2) | ((ly & 1) << 1) | (lz & 1)];
+      }
+
+      Block currentBlock = palette.get(node.type);
+      Material prevBlock = ray.getCurrentMaterial();
+
+      ray.setPrevMaterial(prevBlock, ray.getCurrentData());
+      ray.setCurrentMaterial(currentBlock, node.getData());
+
+      if (currentBlock.localIntersect) {
+        if (currentBlock.intersect(ray, scene)) {
+          if (prevBlock != currentBlock)
+            return true;
+
+          ray.o.scaleAdd(Ray.OFFSET, ray.d);
+          continue;
+        } else {
+          // Exit ray from this local block.
+          ray.setCurrentMaterial(Air.INSTANCE, 0); // Current material is air.
+          ray.exitBlock(x, y, z);
+          continue;
+        }
+      } else if (!currentBlock.isSameMaterial(prevBlock) && currentBlock != Air.INSTANCE) {
+        TexturedBlockModel.getIntersectionColor(ray);
+        return true;
+      }
+
+      // Exit current octree leaf.
+      t = ((lx << level) - ray.o.x) / d.x;
+      if (t > Ray.EPSILON) {
+        tNear = t;
+        nx = 1;
+        ny = nz = 0;
+      } else {
+        t = (((lx + 1) << level) - ray.o.x) / d.x;
+        if (t < tNear && t > Ray.EPSILON) {
+          tNear = t;
+          nx = -1;
+          ny = nz = 0;
+        }
+      }
+
+      t = ((ly << level) - ray.o.y) / d.y;
+      if (t < tNear && t > Ray.EPSILON) {
+        tNear = t;
+        ny = 1;
+        nx = nz = 0;
+      } else {
+        t = (((ly + 1) << level) - ray.o.y) / d.y;
+        if (t < tNear && t > Ray.EPSILON) {
+          tNear = t;
+          ny = -1;
+          nx = nz = 0;
+        }
+      }
+
+      t = ((lz << level) - ray.o.z) / d.z;
+      if (t < tNear && t > Ray.EPSILON) {
+        tNear = t;
+        nz = 1;
+        nx = ny = 0;
+      } else {
+        t = (((lz + 1) << level) - ray.o.z) / d.z;
+        if (t < tNear && t > Ray.EPSILON) {
+          tNear = t;
+          nz = -1;
+          nx = ny = 0;
+        }
+      }
+
+      ray.o.scaleAdd(tNear, d);
+      ray.n.set(nx, ny, nz);
+      ray.distance += tNear;
+      tNear = Double.POSITIVE_INFINITY;
+    }
+  }
+
+  @Override
+  public boolean exitWater(Scene scene, Ray ray, BlockPalette palette) {
+    int level;
+    Octree.Node node;
+    boolean first = true;
+
+    int lx, ly, lz;
+    int x, y, z;
+    int nx = 0, ny = 0, nz = 0;
+    double tNear = Double.POSITIVE_INFINITY;
+    double t;
+    Vector3 d = ray.d;
+
+    while (true) {
+
+      x = (int) QuickMath.floor(ray.o.x + d.x * Ray.OFFSET);
+      y = (int) QuickMath.floor(ray.o.y + d.y * Ray.OFFSET);
+      z = (int) QuickMath.floor(ray.o.z + d.z * Ray.OFFSET);
+
+      node = root;
+      level = depth;
+      lx = x >>> level;
+      ly = y >>> level;
+      lz = z >>> level;
+
+      if (lx != 0 || ly != 0 || lz != 0) {
+
+        // only check octree intersection if this is the first iteration
+        if (first) {
+          // test if it is entering the octree
+          t = -ray.o.x / d.x;
+          if (t > Ray.EPSILON) {
+            tNear = t;
+            nx = 1;
+            ny = nz = 0;
+          }
+          t = ((1 << level) - ray.o.x) / d.x;
+          if (t < tNear && t > Ray.EPSILON) {
+            tNear = t;
+            nx = -1;
+            ny = nz = 0;
+          }
+          t = -ray.o.y / d.y;
+          if (t < tNear && t > Ray.EPSILON) {
+            tNear = t;
+            ny = 1;
+            nx = nz = 0;
+          }
+          t = ((1 << level) - ray.o.y) / d.y;
+          if (t < tNear && t > Ray.EPSILON) {
+            tNear = t;
+            ny = -1;
+            nx = nz = 0;
+          }
+          t = -ray.o.z / d.z;
+          if (t < tNear && t > Ray.EPSILON) {
+            tNear = t;
+            nz = 1;
+            nx = ny = 0;
+          }
+          t = ((1 << level) - ray.o.z) / d.z;
+          if (t < tNear && t > Ray.EPSILON) {
+            tNear = t;
+            nz = -1;
+            nx = ny = 0;
+          }
+
+          if (tNear < Double.MAX_VALUE) {
+            ray.o.scaleAdd(tNear, d);
+            ray.n.set(nx, ny, nz);
+            ray.distance += tNear;
+            tNear = Double.POSITIVE_INFINITY;
+            continue;
+          } else {
+            return false;// outside of octree!
+          }
+        } else {
+          return false;// outside of octree!
+        }
+      }
+
+      first = false;
+
+      while (node.type == BRANCH_NODE) {
+        level -= 1;
+        lx = x >>> level;
+        ly = y >>> level;
+        lz = z >>> level;
+        node = node.children[((lx & 1) << 2) | ((ly & 1) << 1) | (lz & 1)];
+      }
+
+      Block currentBlock = palette.get(node.type);
+      Material prevBlock = ray.getCurrentMaterial();
+
+      ray.setPrevMaterial(prevBlock, ray.getCurrentData());
+      ray.setCurrentMaterial(currentBlock, node.type);
+
+      if (!currentBlock.isWater()) {
+        if (currentBlock.localIntersect) {
+          if (!currentBlock.intersect(ray, scene)) {
+            ray.setCurrentMaterial(Air.INSTANCE, 0);
+          }
+          return true;
+        } else if (currentBlock != Air.INSTANCE) {
+          TexturedBlockModel.getIntersectionColor(ray);
+          return true;
+        } else {
+          return true;
+        }
+      }
+
+      // Exit current octree leaf.
+      if ((node.getData() & (1 << Water.FULL_BLOCK)) == 0) {
+        if (WaterModel.intersectTop(ray)) {
+          ray.setCurrentMaterial(Air.INSTANCE, 0);
+          return true;
+        } else {
+          ray.exitBlock(x, y, z);
+          continue;
+        }
+      }
+
+      t = ((lx << level) - ray.o.x) / d.x;
+      if (t > Ray.EPSILON) {
+        tNear = t;
+        nx = 1;
+        ny = nz = 0;
+      } else {
+        t = (((lx + 1) << level) - ray.o.x) / d.x;
+        if (t < tNear && t > Ray.EPSILON) {
+          tNear = t;
+          nx = -1;
+          ny = nz = 0;
+        }
+      }
+
+      t = ((ly << level) - ray.o.y) / d.y;
+      if (t < tNear && t > Ray.EPSILON) {
+        tNear = t;
+        ny = 1;
+        nx = nz = 0;
+      } else {
+        t = (((ly + 1) << level) - ray.o.y) / d.y;
+        if (t < tNear && t > Ray.EPSILON) {
+          tNear = t;
+          ny = -1;
+          nx = nz = 0;
+        }
+      }
+
+      t = ((lz << level) - ray.o.z) / d.z;
+      if (t < tNear && t > Ray.EPSILON) {
+        tNear = t;
+        nz = 1;
+        nx = ny = 0;
+      } else {
+        t = (((lz + 1) << level) - ray.o.z) / d.z;
+        if (t < tNear && t > Ray.EPSILON) {
+          tNear = t;
+          nz = -1;
+          nx = ny = 0;
+        }
+      }
+
+      ray.o.scaleAdd(tNear, d);
+      ray.n.set(nx, ny, nz);
+      ray.distance += tNear;
+      tNear = Double.POSITIVE_INFINITY;
+    }
+  }
+
+  public int getDepth() {
+    return depth;
+  }
+}

--- a/chunky/src/java/se/llbit/math/NodeBasedOctree.java
+++ b/chunky/src/java/se/llbit/math/NodeBasedOctree.java
@@ -11,6 +11,7 @@ import se.llbit.chunky.model.WaterModel;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.world.Material;
 
+import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 
@@ -488,5 +489,10 @@ public class NodeBasedOctree implements Octree.OctreeImplementation {
 
   public int getDepth() {
     return depth;
+  }
+
+  public static NodeBasedOctree load(DataInputStream in) throws IOException {
+    int treeDepth = in.readInt();
+    return new NodeBasedOctree(treeDepth, Octree.Node.loadNode(in));
   }
 }

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -40,7 +40,19 @@ import se.llbit.log.Log;
  */
 public class Octree {
 
-  static final int BRANCH_NODE = -1;
+  public interface OctreeImplementation {
+    void set(int type, int x, int y, int z);
+    void set(Node data, int x, int y, int z);
+    Node get(int x, int y, int z);
+    Material getMaterial(int x, int y, int z, BlockPalette palette);
+    void store(DataOutputStream output) throws IOException;
+    boolean isInside(Vector3 pos);
+    boolean enterBlock(Scene scene, Ray ray, BlockPalette palette);
+    boolean exitWater(Scene scene, Ray ray, BlockPalette palette);
+    int getDepth();
+  }
+
+  public static final int BRANCH_NODE = -1;
 
   /**
    * The top bit of the type field in a serialized octree node is reserved for indicating
@@ -196,26 +208,12 @@ public class Octree {
   }
 
   /**
-   * Recursive depth of the octree
-   */
-  public final int depth;
-
-  /**
-   * Root node
-   */
-  public final Node root;
-
-  /**
    * Timestamp of last serialization.
    */
   private long timestamp = 0;
 
-  private final Node[] parents;
-  private final Node[] cache;
-  private int cx = 0;
-  private int cy = 0;
-  private int cz = 0;
-  private int cacheLevel;
+  private OctreeImplementation implementation;
+
 
   /**
    * Create a new Octree. The dimensions of the Octree
@@ -228,12 +226,7 @@ public class Octree {
   }
 
   public Octree(int octreeDepth, Node node) {
-    depth = octreeDepth;
-    root = node;
-    parents = new Node[depth];
-    cache = new Node[depth + 1];
-    cache[depth] = root;
-    cacheLevel = depth;
+    implementation = new NodeBasedOctree(octreeDepth, node);
   }
 
   /**
@@ -242,7 +235,7 @@ public class Octree {
    * @param type The new voxel type to be set
    */
   public synchronized void set(int type, int x, int y, int z) {
-    set(new Node(type), x, y, z);
+    implementation.set(type, x, y, z);
   }
 
   /**
@@ -251,79 +244,18 @@ public class Octree {
    * @param data The new voxel to insert.
    */
   public synchronized void set(Node data, int x, int y, int z) {
-    Node node = root;
-    int parentLevel = depth - 1;
-    int position = 0;
-    for (int i = depth - 1; i >= 0; --i) {
-      parents[i] = node;
-
-      if (node.equals(data)) {
-        return;
-      } else if (node.children == null) {
-        node.subdivide();
-        parentLevel = i;
-      }
-
-      int xbit = 1 & (x >> i);
-      int ybit = 1 & (y >> i);
-      int zbit = 1 & (z >> i);
-      position = (xbit << 2) | (ybit << 1) | zbit;
-      node = node.children[position];
-
-    }
-    parents[0].children[position] = data;
-
-    // Merge nodes where all children have been set to the same type.
-    for (int i = 0; i <= parentLevel; ++i) {
-      Node parent = parents[i];
-
-      boolean allSame = true;
-      for (Node child : parent.children) {
-        if (!child.equals(node)) {
-          allSame = false;
-          break;
-        }
-      }
-
-      if (allSame) {
-        parent.merge(node.type);
-        cacheLevel = FastMath.max(i, cacheLevel);
-      } else {
-        break;
-      }
-    }
+    implementation.set(data, x, y, z);
   }
 
   /**
    * @return The voxel type at the given coordinates
    */
   public synchronized Node get(int x, int y, int z) {
-    while (cacheLevel < depth && ((x >>> cacheLevel) != cx ||
-        (y >>> cacheLevel) != cy || (z >>> cacheLevel) != cz))
-      cacheLevel += 1;
-
-    Node node;
-    while (true) {
-      node = cache[cacheLevel];
-      if (node.type != BRANCH_NODE) {
-        break;
-      }
-      cacheLevel -= 1;
-      cx = x >>> cacheLevel;
-      cy = y >>> cacheLevel;
-      cz = z >>> cacheLevel;
-      cache[cacheLevel] =
-          cache[cacheLevel + 1].children[((cx & 1) << 2) | ((cy & 1) << 1) | (cz & 1)];
-    }
-    return node;
+    return implementation.get(x, y, z);
   }
 
   public Material getMaterial(int x, int y, int z, BlockPalette palette) {
-    Node node = get(x, y, z);
-    if (node.type == BRANCH_NODE) {
-      return UnknownBlock.UNKNOWN;
-    }
-    return palette.get(node.type);
+    return implementation.getMaterial(x, y, z, palette);
   }
 
   /**
@@ -332,8 +264,7 @@ public class Octree {
    * @throws IOException
    */
   public void store(DataOutputStream out) throws IOException {
-    out.writeInt(depth);
-    root.store(out);
+    implementation.store(out);
   }
 
   /**
@@ -356,356 +287,18 @@ public class Octree {
    * @return {@code true} if the vector is inside the octree
    */
   public boolean isInside(Vector3 o) {
-    int x = (int) QuickMath.floor(o.x);
-    int y = (int) QuickMath.floor(o.y);
-    int z = (int) QuickMath.floor(o.z);
-
-    int lx = x >>> depth;
-    int ly = y >>> depth;
-    int lz = z >>> depth;
-
-    return lx == 0 && ly == 0 && lz == 0;
+    return implementation.isInside(o);
   }
 
   public boolean enterBlock(Scene scene, Ray ray, BlockPalette palette) {
-    int level;
-    Octree.Node node;
-    boolean first = true;
-
-    int lx, ly, lz;
-    int x, y, z;
-    int nx = 0, ny = 0, nz = 0;
-    double tNear = Double.POSITIVE_INFINITY;
-    double t;
-    Vector3 d = ray.d;
-
-    while (true) {
-
-      // Add small offset past the intersection to avoid
-      // recursion to the same octree node!
-      x = (int) QuickMath.floor(ray.o.x + d.x * Ray.OFFSET);
-      y = (int) QuickMath.floor(ray.o.y + d.y * Ray.OFFSET);
-      z = (int) QuickMath.floor(ray.o.z + d.z * Ray.OFFSET);
-
-      node = root;
-      level = depth;
-      lx = x >>> level;
-      ly = y >>> level;
-      lz = z >>> level;
-
-      if (lx != 0 || ly != 0 || lz != 0) {
-
-        // ray origin is outside octree!
-
-        // only check octree intersection if this is the first iteration
-        if (first) {
-          // test if it is entering the octree
-          t = -ray.o.x / d.x;
-          if (t > Ray.EPSILON) {
-            tNear = t;
-            nx = 1;
-            ny = nz = 0;
-          }
-          t = ((1 << level) - ray.o.x) / d.x;
-          if (t < tNear && t > Ray.EPSILON) {
-            tNear = t;
-            nx = -1;
-            ny = nz = 0;
-          }
-          t = -ray.o.y / d.y;
-          if (t < tNear && t > Ray.EPSILON) {
-            tNear = t;
-            ny = 1;
-            nx = nz = 0;
-          }
-          t = ((1 << level) - ray.o.y) / d.y;
-          if (t < tNear && t > Ray.EPSILON) {
-            tNear = t;
-            ny = -1;
-            nx = nz = 0;
-          }
-          t = -ray.o.z / d.z;
-          if (t < tNear && t > Ray.EPSILON) {
-            tNear = t;
-            nz = 1;
-            nx = ny = 0;
-          }
-          t = ((1 << level) - ray.o.z) / d.z;
-          if (t < tNear && t > Ray.EPSILON) {
-            tNear = t;
-            nz = -1;
-            nx = ny = 0;
-          }
-
-          if (tNear < Double.MAX_VALUE) {
-            ray.o.scaleAdd(tNear, d);
-            ray.n.set(nx, ny, nz);
-            ray.distance += tNear;
-            tNear = Double.POSITIVE_INFINITY;
-            continue;
-          } else {
-            return false;// outside of octree!
-          }
-        } else {
-          return false;// outside of octree!
-        }
-      }
-
-      first = false;
-
-      while (node.type == BRANCH_NODE) {
-        level -= 1;
-        lx = x >>> level;
-        ly = y >>> level;
-        lz = z >>> level;
-        node = node.children[((lx & 1) << 2) | ((ly & 1) << 1) | (lz & 1)];
-      }
-
-      Block currentBlock = palette.get(node.type);
-      Material prevBlock = ray.getCurrentMaterial();
-
-      ray.setPrevMaterial(prevBlock, ray.getCurrentData());
-      ray.setCurrentMaterial(currentBlock, node.getData());
-
-      if (currentBlock.localIntersect) {
-        if (currentBlock.intersect(ray, scene)) {
-          if (prevBlock != currentBlock)
-            return true;
-
-          ray.o.scaleAdd(Ray.OFFSET, ray.d);
-          continue;
-        } else {
-          // Exit ray from this local block.
-          ray.setCurrentMaterial(Air.INSTANCE, 0); // Current material is air.
-          ray.exitBlock(x, y, z);
-          continue;
-        }
-      } else if (!currentBlock.isSameMaterial(prevBlock) && currentBlock != Air.INSTANCE) {
-        TexturedBlockModel.getIntersectionColor(ray);
-        return true;
-      }
-
-      // Exit current octree leaf.
-      t = ((lx << level) - ray.o.x) / d.x;
-      if (t > Ray.EPSILON) {
-        tNear = t;
-        nx = 1;
-        ny = nz = 0;
-      } else {
-        t = (((lx + 1) << level) - ray.o.x) / d.x;
-        if (t < tNear && t > Ray.EPSILON) {
-          tNear = t;
-          nx = -1;
-          ny = nz = 0;
-        }
-      }
-
-      t = ((ly << level) - ray.o.y) / d.y;
-      if (t < tNear && t > Ray.EPSILON) {
-        tNear = t;
-        ny = 1;
-        nx = nz = 0;
-      } else {
-        t = (((ly + 1) << level) - ray.o.y) / d.y;
-        if (t < tNear && t > Ray.EPSILON) {
-          tNear = t;
-          ny = -1;
-          nx = nz = 0;
-        }
-      }
-
-      t = ((lz << level) - ray.o.z) / d.z;
-      if (t < tNear && t > Ray.EPSILON) {
-        tNear = t;
-        nz = 1;
-        nx = ny = 0;
-      } else {
-        t = (((lz + 1) << level) - ray.o.z) / d.z;
-        if (t < tNear && t > Ray.EPSILON) {
-          tNear = t;
-          nz = -1;
-          nx = ny = 0;
-        }
-      }
-
-      ray.o.scaleAdd(tNear, d);
-      ray.n.set(nx, ny, nz);
-      ray.distance += tNear;
-      tNear = Double.POSITIVE_INFINITY;
-    }
+    return implementation.enterBlock(scene, ray, palette);
   }
 
   /**
    * Advance the ray until it leaves the current water body.
    */
   public boolean exitWater(Scene scene, Ray ray, BlockPalette palette) {
-    int level;
-    Octree.Node node;
-    boolean first = true;
-
-    int lx, ly, lz;
-    int x, y, z;
-    int nx = 0, ny = 0, nz = 0;
-    double tNear = Double.POSITIVE_INFINITY;
-    double t;
-    Vector3 d = ray.d;
-
-    while (true) {
-
-      x = (int) QuickMath.floor(ray.o.x + d.x * Ray.OFFSET);
-      y = (int) QuickMath.floor(ray.o.y + d.y * Ray.OFFSET);
-      z = (int) QuickMath.floor(ray.o.z + d.z * Ray.OFFSET);
-
-      node = root;
-      level = depth;
-      lx = x >>> level;
-      ly = y >>> level;
-      lz = z >>> level;
-
-      if (lx != 0 || ly != 0 || lz != 0) {
-
-        // only check octree intersection if this is the first iteration
-        if (first) {
-          // test if it is entering the octree
-          t = -ray.o.x / d.x;
-          if (t > Ray.EPSILON) {
-            tNear = t;
-            nx = 1;
-            ny = nz = 0;
-          }
-          t = ((1 << level) - ray.o.x) / d.x;
-          if (t < tNear && t > Ray.EPSILON) {
-            tNear = t;
-            nx = -1;
-            ny = nz = 0;
-          }
-          t = -ray.o.y / d.y;
-          if (t < tNear && t > Ray.EPSILON) {
-            tNear = t;
-            ny = 1;
-            nx = nz = 0;
-          }
-          t = ((1 << level) - ray.o.y) / d.y;
-          if (t < tNear && t > Ray.EPSILON) {
-            tNear = t;
-            ny = -1;
-            nx = nz = 0;
-          }
-          t = -ray.o.z / d.z;
-          if (t < tNear && t > Ray.EPSILON) {
-            tNear = t;
-            nz = 1;
-            nx = ny = 0;
-          }
-          t = ((1 << level) - ray.o.z) / d.z;
-          if (t < tNear && t > Ray.EPSILON) {
-            tNear = t;
-            nz = -1;
-            nx = ny = 0;
-          }
-
-          if (tNear < Double.MAX_VALUE) {
-            ray.o.scaleAdd(tNear, d);
-            ray.n.set(nx, ny, nz);
-            ray.distance += tNear;
-            tNear = Double.POSITIVE_INFINITY;
-            continue;
-          } else {
-            return false;// outside of octree!
-          }
-        } else {
-          return false;// outside of octree!
-        }
-      }
-
-      first = false;
-
-      while (node.type == BRANCH_NODE) {
-        level -= 1;
-        lx = x >>> level;
-        ly = y >>> level;
-        lz = z >>> level;
-        node = node.children[((lx & 1) << 2) | ((ly & 1) << 1) | (lz & 1)];
-      }
-
-      Block currentBlock = palette.get(node.type);
-      Material prevBlock = ray.getCurrentMaterial();
-
-      ray.setPrevMaterial(prevBlock, ray.getCurrentData());
-      ray.setCurrentMaterial(currentBlock, node.type);
-
-      if (!currentBlock.isWater()) {
-        if (currentBlock.localIntersect) {
-          if (!currentBlock.intersect(ray, scene)) {
-            ray.setCurrentMaterial(Air.INSTANCE, 0);
-          }
-          return true;
-        } else if (currentBlock != Air.INSTANCE) {
-          TexturedBlockModel.getIntersectionColor(ray);
-          return true;
-        } else {
-          return true;
-        }
-      }
-
-      // Exit current octree leaf.
-      if ((node.getData() & (1 << Water.FULL_BLOCK)) == 0) {
-        if (WaterModel.intersectTop(ray)) {
-          ray.setCurrentMaterial(Air.INSTANCE, 0);
-          return true;
-        } else {
-          ray.exitBlock(x, y, z);
-          continue;
-        }
-      }
-
-      t = ((lx << level) - ray.o.x) / d.x;
-      if (t > Ray.EPSILON) {
-        tNear = t;
-        nx = 1;
-        ny = nz = 0;
-      } else {
-        t = (((lx + 1) << level) - ray.o.x) / d.x;
-        if (t < tNear && t > Ray.EPSILON) {
-          tNear = t;
-          nx = -1;
-          ny = nz = 0;
-        }
-      }
-
-      t = ((ly << level) - ray.o.y) / d.y;
-      if (t < tNear && t > Ray.EPSILON) {
-        tNear = t;
-        ny = 1;
-        nx = nz = 0;
-      } else {
-        t = (((ly + 1) << level) - ray.o.y) / d.y;
-        if (t < tNear && t > Ray.EPSILON) {
-          tNear = t;
-          ny = -1;
-          nx = nz = 0;
-        }
-      }
-
-      t = ((lz << level) - ray.o.z) / d.z;
-      if (t < tNear && t > Ray.EPSILON) {
-        tNear = t;
-        nz = 1;
-        nx = ny = 0;
-      } else {
-        t = (((lz + 1) << level) - ray.o.z) / d.z;
-        if (t < tNear && t > Ray.EPSILON) {
-          tNear = t;
-          nz = -1;
-          nx = ny = 0;
-        }
-      }
-
-      ray.o.scaleAdd(tNear, d);
-      ray.n.set(nx, ny, nz);
-      ray.distance += tNear;
-      tNear = Double.POSITIVE_INFINITY;
-    }
+    return implementation.exitWater(scene, ray, palette);
   }
 
   /**
@@ -720,6 +313,10 @@ public class Octree {
    */
   public long getTimestamp() {
     return timestamp;
+  }
+
+  public int getDepth() {
+    return implementation.getDepth();
   }
 
 }

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -214,7 +214,7 @@ public class Octree {
 
   private OctreeImplementation implementation;
 
-  static private boolean usePacked = true;
+  static private boolean usePacked = !System.getProperty("chunky.useLegacyOctree", "false").equals("true");
 
   /**
    * Create a new Octree. The dimensions of the Octree

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -323,8 +323,8 @@ public class Octree {
    * Replace the implementation for the packed one
    */
   public void pack() {
-//    if(implementation instanceof NodeBasedOctree)
-//      implementation = new PackedOctree(implementation.getDepth(), ((NodeBasedOctree)implementation).root);
+    if(implementation instanceof NodeBasedOctree)
+      implementation = new PackedOctree(implementation.getDepth(), ((NodeBasedOctree)implementation).root);
   }
 
 }

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -367,7 +367,11 @@ public class Octree {
 
   private void switchToNodeBased() {
     if(implementation instanceof PackedOctree) {
-      implementation = ((PackedOctree)implementation).toNodeBasedOctree();
+      try {
+        implementation = ((PackedOctree) implementation).toNodeBasedOctree();
+      } catch(PackedOctree.OctreeTooBigException e) {
+        // If octree is too big, do nothing, keep the node based implementation
+      }
     }
   }
 

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -319,4 +319,12 @@ public class Octree {
     return implementation.getDepth();
   }
 
+  /**
+   * Replace the implementation for the packed one
+   */
+  public void pack() {
+//    if(implementation instanceof NodeBasedOctree)
+//      implementation = new PackedOctree(implementation.getDepth(), ((NodeBasedOctree)implementation).root);
+  }
+
 }

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -58,7 +58,7 @@ public class Octree {
    * The top bit of the type field in a serialized octree node is reserved for indicating
    * if the node is a data node.
    */
-  static final int DATA_FLAG = 0x80000000;
+  public static final int DATA_FLAG = 0x80000000;
 
   /** An Octree node. */
   public static class Node {
@@ -214,8 +214,7 @@ public class Octree {
 
   private OctreeImplementation implementation;
 
-
-  static private boolean usePacked = false;
+  static private boolean usePacked = true;
 
   /**
    * Create a new Octree. The dimensions of the Octree
@@ -232,6 +231,10 @@ public class Octree {
 
   public Octree(int octreeDepth, Node node) {
     implementation = new NodeBasedOctree(octreeDepth, node);
+  }
+
+  protected Octree(OctreeImplementation impl) {
+    implementation = impl;
   }
 
   /**
@@ -279,10 +282,11 @@ public class Octree {
    * @throws IOException
    */
   public static Octree load(DataInputStream in) throws IOException {
-    int treeDepth = in.readInt();
-    Octree tree = new Octree(treeDepth, Node.loadNode(in));
-    //Log.info("Loaded octree with " + size + " nodes.");
-    return tree;
+    if(usePacked) {
+      return new Octree(PackedOctree.load(in));
+    } else {
+      return new Octree(NodeBasedOctree.load(in));
+    }
   }
 
   /**

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -215,6 +215,8 @@ public class Octree {
   private OctreeImplementation implementation;
 
 
+  static private boolean usePacked = false;
+
   /**
    * Create a new Octree. The dimensions of the Octree
    * are 2^levels.
@@ -222,7 +224,10 @@ public class Octree {
    * @param octreeDepth The number of levels in the Octree.
    */
   public Octree(int octreeDepth) {
-    this(octreeDepth, new Node(0));
+    if(usePacked)
+      implementation = new PackedOctree(octreeDepth);
+    else
+      implementation = new NodeBasedOctree(octreeDepth, new Node(0));
   }
 
   public Octree(int octreeDepth, Node node) {
@@ -323,8 +328,9 @@ public class Octree {
    * Replace the implementation for the packed one
    */
   public void pack() {
-    if(implementation instanceof NodeBasedOctree)
-      implementation = new PackedOctree(implementation.getDepth(), ((NodeBasedOctree)implementation).root);
+    if(usePacked)
+      if(implementation instanceof NodeBasedOctree)
+        implementation = new PackedOctree(implementation.getDepth(), ((NodeBasedOctree)implementation).root);
   }
 
 }

--- a/chunky/src/java/se/llbit/math/PackedOctree.java
+++ b/chunky/src/java/se/llbit/math/PackedOctree.java
@@ -1,0 +1,508 @@
+package se.llbit.math;
+
+import se.llbit.chunky.block.Air;
+import se.llbit.chunky.block.Block;
+import se.llbit.chunky.block.UnknownBlock;
+import se.llbit.chunky.block.Water;
+import se.llbit.chunky.chunk.BlockPalette;
+import se.llbit.chunky.model.TexturedBlockModel;
+import se.llbit.chunky.model.WaterModel;
+import se.llbit.chunky.renderer.scene.Scene;
+import se.llbit.chunky.world.Material;
+import sun.jvm.hotspot.oops.BranchData;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import static se.llbit.math.Octree.BRANCH_NODE;
+
+/**
+ * This is a packed representation of an octree
+ * the whole octree is stored in a int array to reduce memory usage and
+ * hopefully improve performance by being more cache-friendly
+ *
+ * (At least for now) this version only implements a subset of what is needed,
+ * it is intented to be
+ */
+public class PackedOctree implements Octree.OctreeImplementation {
+  /**
+   * The whole tree data is store in a int array
+   *
+   * Each node is made of several values :
+   *  - the node type (could be a branch node or the type of block contained)
+   *  - optional additional data
+   *  - the index of its first child (if branch node)
+   *
+   *  As nodes are stored linearly, we place siblings nodes in a row and so
+   *  we only need the index of the first child as the following are just after
+   *
+   *  The node type is always positive, we can use this knowledge to compress the node to 2 ints:
+   *  one will contains the index of the first child if it is positive or the negation of the type
+   *  the other will contain the additional data
+   *
+   *  This implementation is inspired by this stackoverflow answer
+   *  https://stackoverflow.com/questions/41946007/efficient-and-well-explained-implementation-of-a-quadtree-for-2d-collision-det#answer-48330314
+   *
+   *  Note: I think only leaf nodes can have additional data. If that is indeed the case
+   *  we could potentially optimize further by only storing the index for branch nodes
+   */
+  private final int[] treeData;
+
+  private final int depth;
+
+  /**
+   * We build the tree by walking an existing tree and recreating it in this format
+   * @param depth The depth of the tree
+   * @param root The root of the tree to recreate
+   */
+  public PackedOctree(int depth, Octree.Node root) {
+    this.depth = depth;
+    int nodeCount = nodeCount(root);
+    treeData = new int[nodeCount*2];
+    addNode(root, 0, 2);
+  }
+
+  private static int nodeCount(Octree.Node node) {
+    if(node.type == BRANCH_NODE) {
+      return 1
+        + nodeCount(node.children[0])
+        + nodeCount(node.children[1])
+        + nodeCount(node.children[2])
+        + nodeCount(node.children[3])
+        + nodeCount(node.children[4])
+        + nodeCount(node.children[5])
+        + nodeCount(node.children[6])
+        + nodeCount(node.children[7]);
+    } else {
+      return 1;
+    }
+  }
+
+  /**
+   * Add a node at the next free index and call recursively on children
+   * @param node The node to add
+   * @param nodeIndex The index of the node currently being added
+   * @param nextFreeIndex The next free index before adding the node
+   * @return The next free index after adding the subtree
+   */
+  private int addNode(Octree.Node node, int nodeIndex, int nextFreeIndex) {
+    // Unconditionally add data
+    treeData[nodeIndex+1] = node.getData();
+    if(node.type == BRANCH_NODE) {
+      treeData[nodeIndex] = nextFreeIndex;
+      int newNextFreeIndex = nextFreeIndex + 8*2;
+      for(int i = 0; i < 8; ++i) {
+        newNextFreeIndex = addNode(node.children[i], nextFreeIndex+2*i, newNextFreeIndex);
+      }
+      return newNextFreeIndex;
+    } else {
+      treeData[nodeIndex] = -node.type; // Store the negation of the type
+      return nextFreeIndex;
+    }
+  }
+
+  @Override
+  public void set(int type, int x, int y, int z) {
+    throw new RuntimeException("Not implemented");
+  }
+
+  @Override
+  public void set(Octree.Node data, int x, int y, int z) {
+    throw new RuntimeException("Not implemented");
+  }
+
+  private int getNodeIndex(int x, int y, int z) {
+    int nodeIndex = 0;
+    int level = depth;
+    while(treeData[nodeIndex] > 0) {
+      level -= 1;
+      int lx = x >>> level;
+      int ly = y >>> level;
+      int lz = z >>> level;
+      nodeIndex = treeData[nodeIndex] + (((lx & 1) << 2) | ((ly & 1) << 1) | (lz & 1)) * 2;
+    }
+    return nodeIndex;
+  }
+
+  @Override
+  public Octree.Node get(int x, int y, int z) {
+    int nodeIndex = getNodeIndex(x, y, z);
+
+    Octree.Node node = new Octree.DataNode(treeData[nodeIndex] > 0 ? BRANCH_NODE : -treeData[nodeIndex], treeData[nodeIndex+1]);
+
+    // Return dummy Node, will work if only type and data are used, breaks if children are needed
+    return node;
+  }
+
+  @Override
+  public Material getMaterial(int x, int y, int z, BlockPalette palette) {
+    // Building the dummy node is useless here
+    int nodeIndex = getNodeIndex(x, y, z);
+    if(treeData[nodeIndex] > 0) {
+      return UnknownBlock.UNKNOWN;
+    }
+    return palette.get(-treeData[nodeIndex]);
+  }
+
+  @Override
+  public void store(DataOutputStream output) throws IOException {
+    throw new RuntimeException("Not implemented");
+  }
+
+  @Override
+  public boolean isInside(Vector3 o) {
+    int x = (int) QuickMath.floor(o.x);
+    int y = (int) QuickMath.floor(o.y);
+    int z = (int) QuickMath.floor(o.z);
+
+    int lx = x >>> depth;
+    int ly = y >>> depth;
+    int lz = z >>> depth;
+
+    return lx == 0 && ly == 0 && lz == 0;
+  }
+
+  @Override
+  public boolean enterBlock(Scene scene, Ray ray, BlockPalette palette) {
+    int level;
+    int nodeIndex;
+    boolean first = true;
+
+    int lx, ly, lz;
+    int x, y, z;
+    int nx = 0, ny = 0, nz = 0;
+    double tNear = Double.POSITIVE_INFINITY;
+    double t;
+    Vector3 d = ray.d;
+
+    while (true) {
+      // Add small offset past the intersection to avoid
+      // recursion to the same octree node!
+      x = (int) QuickMath.floor(ray.o.x + d.x * Ray.OFFSET);
+      y = (int) QuickMath.floor(ray.o.y + d.y * Ray.OFFSET);
+      z = (int) QuickMath.floor(ray.o.z + d.z * Ray.OFFSET);
+
+      nodeIndex = 0;
+      level = depth;
+      lx = x >>> level;
+      ly = y >>> level;
+      lz = z >>> level;
+
+      if (lx != 0 || ly != 0 || lz != 0) {
+
+        // ray origin is outside octree!
+
+        // only check octree intersection if this is the first iteration
+        if (first) {
+          // test if it is entering the octree
+          t = -ray.o.x / d.x;
+          if (t > Ray.EPSILON) {
+            tNear = t;
+            nx = 1;
+            ny = nz = 0;
+          }
+          t = ((1 << level) - ray.o.x) / d.x;
+          if (t < tNear && t > Ray.EPSILON) {
+            tNear = t;
+            nx = -1;
+            ny = nz = 0;
+          }
+          t = -ray.o.y / d.y;
+          if (t < tNear && t > Ray.EPSILON) {
+            tNear = t;
+            ny = 1;
+            nx = nz = 0;
+          }
+          t = ((1 << level) - ray.o.y) / d.y;
+          if (t < tNear && t > Ray.EPSILON) {
+            tNear = t;
+            ny = -1;
+            nx = nz = 0;
+          }
+          t = -ray.o.z / d.z;
+          if (t < tNear && t > Ray.EPSILON) {
+            tNear = t;
+            nz = 1;
+            nx = ny = 0;
+          }
+          t = ((1 << level) - ray.o.z) / d.z;
+          if (t < tNear && t > Ray.EPSILON) {
+            tNear = t;
+            nz = -1;
+            nx = ny = 0;
+          }
+
+          if (tNear < Double.MAX_VALUE) {
+            ray.o.scaleAdd(tNear, d);
+            ray.n.set(nx, ny, nz);
+            ray.distance += tNear;
+            tNear = Double.POSITIVE_INFINITY;
+            continue;
+          } else {
+            return false;// outside of octree!
+          }
+        } else {
+          return false;// outside of octree!
+        }
+      }
+
+      first = false;
+
+      while(treeData[nodeIndex] > 0) {
+        level -= 1;
+        lx = x >>> level;
+        ly = y >>> level;
+        lz = z >>> level;
+        nodeIndex = treeData[nodeIndex] + (((lx & 1) << 2) | ((ly & 1) << 1) | (lz & 1)) * 2;
+      }
+
+      Block currentBlock = palette.get(-treeData[nodeIndex]);
+      Material prevBlock = ray.getCurrentMaterial();
+
+      ray.setPrevMaterial(prevBlock, ray.getCurrentData());
+      ray.setCurrentMaterial(currentBlock, treeData[nodeIndex+1]);
+
+      if (currentBlock.localIntersect) {
+        if (currentBlock.intersect(ray, scene)) {
+          if (prevBlock != currentBlock)
+            return true;
+
+          ray.o.scaleAdd(Ray.OFFSET, ray.d);
+          continue;
+        } else {
+          // Exit ray from this local block.
+          ray.setCurrentMaterial(Air.INSTANCE, 0); // Current material is air.
+          ray.exitBlock(x, y, z);
+          continue;
+        }
+      } else if (!currentBlock.isSameMaterial(prevBlock) && currentBlock != Air.INSTANCE) {
+        TexturedBlockModel.getIntersectionColor(ray);
+        return true;
+      }
+
+      // Exit current octree leaf.
+      t = ((lx << level) - ray.o.x) / d.x;
+      if (t > Ray.EPSILON) {
+        tNear = t;
+        nx = 1;
+        ny = nz = 0;
+      } else {
+        t = (((lx + 1) << level) - ray.o.x) / d.x;
+        if (t < tNear && t > Ray.EPSILON) {
+          tNear = t;
+          nx = -1;
+          ny = nz = 0;
+        }
+      }
+
+      t = ((ly << level) - ray.o.y) / d.y;
+      if (t < tNear && t > Ray.EPSILON) {
+        tNear = t;
+        ny = 1;
+        nx = nz = 0;
+      } else {
+        t = (((ly + 1) << level) - ray.o.y) / d.y;
+        if (t < tNear && t > Ray.EPSILON) {
+          tNear = t;
+          ny = -1;
+          nx = nz = 0;
+        }
+      }
+
+      t = ((lz << level) - ray.o.z) / d.z;
+      if (t < tNear && t > Ray.EPSILON) {
+        tNear = t;
+        nz = 1;
+        nx = ny = 0;
+      } else {
+        t = (((lz + 1) << level) - ray.o.z) / d.z;
+        if (t < tNear && t > Ray.EPSILON) {
+          tNear = t;
+          nz = -1;
+          nx = ny = 0;
+        }
+      }
+
+      ray.o.scaleAdd(tNear, d);
+      ray.n.set(nx, ny, nz);
+      ray.distance += tNear;
+      tNear = Double.POSITIVE_INFINITY;
+    }
+  }
+
+  @Override
+  public boolean exitWater(Scene scene, Ray ray, BlockPalette palette) {
+    int level;
+    int nodeIndex;
+    boolean first = true;
+
+    int lx, ly, lz;
+    int x, y, z;
+    int nx = 0, ny = 0, nz = 0;
+    double tNear = Double.POSITIVE_INFINITY;
+    double t;
+    Vector3 d = ray.d;
+
+    while (true) {
+
+      x = (int) QuickMath.floor(ray.o.x + d.x * Ray.OFFSET);
+      y = (int) QuickMath.floor(ray.o.y + d.y * Ray.OFFSET);
+      z = (int) QuickMath.floor(ray.o.z + d.z * Ray.OFFSET);
+
+      nodeIndex = 0;
+      level = depth;
+      lx = x >>> level;
+      ly = y >>> level;
+      lz = z >>> level;
+
+      if (lx != 0 || ly != 0 || lz != 0) {
+
+        // only check octree intersection if this is the first iteration
+        if (first) {
+          // test if it is entering the octree
+          t = -ray.o.x / d.x;
+          if (t > Ray.EPSILON) {
+            tNear = t;
+            nx = 1;
+            ny = nz = 0;
+          }
+          t = ((1 << level) - ray.o.x) / d.x;
+          if (t < tNear && t > Ray.EPSILON) {
+            tNear = t;
+            nx = -1;
+            ny = nz = 0;
+          }
+          t = -ray.o.y / d.y;
+          if (t < tNear && t > Ray.EPSILON) {
+            tNear = t;
+            ny = 1;
+            nx = nz = 0;
+          }
+          t = ((1 << level) - ray.o.y) / d.y;
+          if (t < tNear && t > Ray.EPSILON) {
+            tNear = t;
+            ny = -1;
+            nx = nz = 0;
+          }
+          t = -ray.o.z / d.z;
+          if (t < tNear && t > Ray.EPSILON) {
+            tNear = t;
+            nz = 1;
+            nx = ny = 0;
+          }
+          t = ((1 << level) - ray.o.z) / d.z;
+          if (t < tNear && t > Ray.EPSILON) {
+            tNear = t;
+            nz = -1;
+            nx = ny = 0;
+          }
+
+          if (tNear < Double.MAX_VALUE) {
+            ray.o.scaleAdd(tNear, d);
+            ray.n.set(nx, ny, nz);
+            ray.distance += tNear;
+            tNear = Double.POSITIVE_INFINITY;
+            continue;
+          } else {
+            return false;// outside of octree!
+          }
+        } else {
+          return false;// outside of octree!
+        }
+      }
+
+      first = false;
+
+      while(treeData[nodeIndex] > 0) {
+        level -= 1;
+        lx = x >>> level;
+        ly = y >>> level;
+        lz = z >>> level;
+        nodeIndex = treeData[nodeIndex] + (((lx & 1) << 2) | ((ly & 1) << 1) | (lz & 1)) * 2;
+      }
+
+      Block currentBlock = palette.get(-treeData[nodeIndex]);
+      Material prevBlock = ray.getCurrentMaterial();
+
+      ray.setPrevMaterial(prevBlock, ray.getCurrentData());
+      ray.setCurrentMaterial(currentBlock, treeData[nodeIndex+1]);
+
+      if (!currentBlock.isWater()) {
+        if (currentBlock.localIntersect) {
+          if (!currentBlock.intersect(ray, scene)) {
+            ray.setCurrentMaterial(Air.INSTANCE, 0);
+          }
+          return true;
+        } else if (currentBlock != Air.INSTANCE) {
+          TexturedBlockModel.getIntersectionColor(ray);
+          return true;
+        } else {
+          return true;
+        }
+      }
+
+      // Exit current octree leaf.
+      if ((treeData[nodeIndex+1] & (1 << Water.FULL_BLOCK)) == 0) {
+        if (WaterModel.intersectTop(ray)) {
+          ray.setCurrentMaterial(Air.INSTANCE, 0);
+          return true;
+        } else {
+          ray.exitBlock(x, y, z);
+          continue;
+        }
+      }
+
+      t = ((lx << level) - ray.o.x) / d.x;
+      if (t > Ray.EPSILON) {
+        tNear = t;
+        nx = 1;
+        ny = nz = 0;
+      } else {
+        t = (((lx + 1) << level) - ray.o.x) / d.x;
+        if (t < tNear && t > Ray.EPSILON) {
+          tNear = t;
+          nx = -1;
+          ny = nz = 0;
+        }
+      }
+
+      t = ((ly << level) - ray.o.y) / d.y;
+      if (t < tNear && t > Ray.EPSILON) {
+        tNear = t;
+        ny = 1;
+        nx = nz = 0;
+      } else {
+        t = (((ly + 1) << level) - ray.o.y) / d.y;
+        if (t < tNear && t > Ray.EPSILON) {
+          tNear = t;
+          ny = -1;
+          nx = nz = 0;
+        }
+      }
+
+      t = ((lz << level) - ray.o.z) / d.z;
+      if (t < tNear && t > Ray.EPSILON) {
+        tNear = t;
+        nz = 1;
+        nx = ny = 0;
+      } else {
+        t = (((lz + 1) << level) - ray.o.z) / d.z;
+        if (t < tNear && t > Ray.EPSILON) {
+          tNear = t;
+          nz = -1;
+          nx = ny = 0;
+        }
+      }
+
+      ray.o.scaleAdd(tNear, d);
+      ray.n.set(nx, ny, nz);
+      ray.distance += tNear;
+      tNear = Double.POSITIVE_INFINITY;
+    }
+  }
+
+  @Override
+  public int getDepth() {
+    return depth;
+  }
+}

--- a/chunky/src/java/se/llbit/math/PackedOctree.java
+++ b/chunky/src/java/se/llbit/math/PackedOctree.java
@@ -89,12 +89,14 @@ public class PackedOctree implements Octree.OctreeImplementation {
    */
   public PackedOctree(int depth, Octree.Node root) {
     this.depth = depth;
-    int nodeCount = nodeCount(root);
-    int arraySize = Math.max(nodeCount*2, 64);
-    treeData = new int[arraySize];
+    long nodeCount = nodeCount(root);
+    long arraySize = Math.max(nodeCount*2, 64);
+    if(arraySize > (long)MAX_ARRAY_SIZE)
+      throw new OctreeTooBigException();
+    treeData = new int[(int)arraySize];
     addNode(root, 0, 2);
     freeHead = -1; // No holes
-    size = nodeCount*2;
+    size = (int)nodeCount*2;
   }
 
   /**
@@ -111,7 +113,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
     freeHead = -1;
   }
 
-  private static int nodeCount(Octree.Node node) {
+  private static long nodeCount(Octree.Node node) {
     if(node.type == BRANCH_NODE) {
       return 1
         + nodeCount(node.children[0])

--- a/chunky/src/java/se/llbit/math/PackedOctree.java
+++ b/chunky/src/java/se/llbit/math/PackedOctree.java
@@ -258,7 +258,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
     }
     int finalNodeIndex = treeData[parents[0]] + position*2;
     treeData[finalNodeIndex] = -data.type; // Store negation of the type
-    treeData[finalNodeIndex] = data.getData();
+    treeData[finalNodeIndex+1] = data.getData();
 
     // Merge nodes where all children have been set to the same type.
     for (int i = 0; i <= parentLevel; ++i) {


### PR DESCRIPTION
This PR adds a new implementation of the octree but also leaves the old one. The implementation is abstracted a bit, allowing the use of a different octree implementation with the same octree.

This new implementation doesn't use Nodes as its internal representation, it uses a big int array to be more memory efficient. Nonetheless it offers the same interface that the old implementation, limiting the need to change code using the octree. (the depth is no longer available but came be replaced by a call to getDepth()).

The idea behind this implementation is to reduce greatly the memory usage of the octree and, hopefully, improving the performance by being more cache friendly (the algorithms are the exact same). I suggest reading the code if you are curious how it works, there are comments explaining.
From my limited testing, it seems that both of this goal have been reached. The memory usage of this implementation is almost a fifth of the old one's, this almost halves the memory usage at the process level for a scene with 4k chunks. As for the performance, i've seen an improvement of 30% in render time for a scene with 1k chunks and of 40% for a scene with 4k chunks.

One caveat with this implementation is that, as everything is stored in a single array, sometime the octree could be too big to fit inside. When this is the case the octree falls back to the old, node-based, implementation