### PR TITLE
Fix delay before rendering

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/RenderWorker.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/RenderWorker.java
@@ -74,7 +74,7 @@ public class RenderWorker extends Thread {
 
         // Sleep to manage CPU utilization.
         if (jobTime > SLEEP_INTERVAL) {
-          if (manager.cpuLoad < 100) {
+          if (manager.cpuLoad < 100 && manager.getBufferedScene().getMode() != RenderMode.PREVIEW) {
             // sleep = jobTime * (1-utilization) / utilization
             double load = (100.0 - manager.cpuLoad) / manager.cpuLoad;
             sleep((long) ((jobTime / 1000000.0) * load));


### PR DESCRIPTION
Fixes #603 
Fixes #403 

Regarding #403: The second commit fixes what llbit describes in that issue: The calculation of `jobTime` used to include the time that the thread waited for a job so the the sleep time was way too long.