### PR TITLE
Fix silly error in octree

### DIFF
--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -360,18 +360,20 @@ public class Octree {
    * Replace the implementation for the packed one
    */
   public void pack() {
-    if(usePacked)
-      if(implementation instanceof NodeBasedOctree)
-        implementation = new PackedOctree(implementation.getDepth(), ((NodeBasedOctree)implementation).root);
+    if(usePacked) {
+      if(implementation instanceof NodeBasedOctree) {
+        try {
+          implementation = new PackedOctree(implementation.getDepth(), ((NodeBasedOctree) implementation).root);
+        } catch(PackedOctree.OctreeTooBigException e) {
+          // If octree is too big, do nothing, keep the node based implementation
+        }
+      }
+    }
   }
 
   private void switchToNodeBased() {
     if(implementation instanceof PackedOctree) {
-      try {
-        implementation = ((PackedOctree) implementation).toNodeBasedOctree();
-      } catch(PackedOctree.OctreeTooBigException e) {
-        // If octree is too big, do nothing, keep the node based implementation
-      }
+      implementation = ((PackedOctree) implementation).toNodeBasedOctree();
     }
   }
 


### PR DESCRIPTION
When adding the fallback mechanism i made a silly error and added error handling to the wrong method. 
As of now, it won't cause any problem as the method that needs error handling isn't called anymore and the the one just check for error that will never happen, but it doesn't make sense and it's better to fix that