### PR TITLE
Fix water bug in packed octree

### DIFF
--- a/chunky/src/java/se/llbit/math/PackedOctree.java
+++ b/chunky/src/java/se/llbit/math/PackedOctree.java
@@ -226,10 +226,11 @@ public class PackedOctree implements Octree.OctreeImplementation {
    * @param nodeIndex The index of the node to merge
    * @param typeNegation The negation of the type (the value directly stored in the array)
    */
-  private void mergeNode(int nodeIndex, int typeNegation) {
+  private void mergeNode(int nodeIndex, int typeNegation, int data) {
     int childrenIndex = treeData[nodeIndex];
     freeSpace(childrenIndex); // Delete children
     treeData[nodeIndex] = typeNegation; // Make the node a leaf one
+    treeData[nodeIndex+1] = data;
   }
 
   /**
@@ -307,7 +308,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
       }
 
       if (allSame) {
-        mergeNode(parentIndex, treeData[nodeIndex]);
+        mergeNode(parentIndex, treeData[nodeIndex], treeData[nodeIndex+1]);
       } else {
         break;
       }


### PR DESCRIPTION
This PR fixes the bug causing water not to look as expected when using the packed octree

expected result:
![water-node-octree](https://user-images.githubusercontent.com/23342398/84574009-32fe7480-ada4-11ea-84ee-8889fc283d31.png)

result with buggy packed octree:
![water-packed-octree](https://user-images.githubusercontent.com/23342398/84574032-5aedd800-ada4-11ea-931f-c755397fa858.png)

This being said, i believe this PR needs a bit a discussion before being merged.
As i've explain earlier on discord, this issue does not occur with the node based octree because, when testing if children must be merged, they all are compared against the old node that has just been replaced that prevents the merging from happening because the children, even if they all compare equals don't compare equals to the old node.
I believe this behavior is a bug but i think its only bad consequence is that sometimes nodes are not merged when they could have been, wasting a bit of memory.

The bug that i think is really the cause of the water problem is the fact that when merging nodes, the data is not propagated to the parent. This is the bug fixed by this PR (only for the packed octree).
This bug is present in the node based octree but its effect wasn't noticeable because of the other bug that prevents merging.

To recap, from my understanding, there are 3 bugs, 2 being the same bug in two octree implementation. The bug in packed octree was noticeable, but the 2 bugs in nodes based octree weren't cause they are "cancelling" each other.

I think we should fix the 2 bugs in the node based octree as well but i'd like to wait for feedback to see if my interpretation is not wrong.