### PR TITLE
Refactor octree intersection

### DIFF
--- a/chunky/src/java/se/llbit/math/NodeBasedOctree.java
+++ b/chunky/src/java/se/llbit/math/NodeBasedOctree.java
@@ -165,7 +165,7 @@ public class NodeBasedOctree implements Octree.OctreeImplementation {
   }
 
   /**
-   * Moves the ray to the of the octree.
+   * Moves the ray to the boundary of the octree.
    * @param ray Ray that will be moved to the boundary of the octree. The origin, distance and normals will be modified.
    * @return {@code false} if the ray doesn't intersect the octree.
    */

--- a/chunky/src/java/se/llbit/math/NodeBasedOctree.java
+++ b/chunky/src/java/se/llbit/math/NodeBasedOctree.java
@@ -239,11 +239,17 @@ public class NodeBasedOctree implements Octree.OctreeImplementation {
     return true;
   }
 
+  /**
+   *  {@inheritDoc}
+   */
   @Override
   public boolean enterBlock(Scene scene, Ray ray, BlockPalette palette) {
     if (!isInside(ray.o) && !enterOctree(ray))
       return false;
 
+    // Marching is done in a top-down fashion: at each step, the octree is descended from the root to find the leaf
+    // node the ray is in. Terminating the march is then decided based on the block type in that leaf node. Finally the
+    // ray is advanced to the boundary of the current leaf node and the next, ready for the next iteration.
     while (true) {
       // Add small offset past the intersection to avoid
       // recursion to the same octree node!
@@ -347,11 +353,17 @@ public class NodeBasedOctree implements Octree.OctreeImplementation {
     }
   }
 
+  /**
+   *  {@inheritDoc}
+   */
   @Override
   public boolean exitWater(Scene scene, Ray ray, BlockPalette palette) {
     if (!isInside(ray.o) && !enterOctree(ray))
       return false;
 
+    // Marching is done in a top-down fashion: at each step, the octree is descended from the root to find the leaf
+    // node the ray is in. Terminating the march is then decided based on the block type in that leaf node. Finally the
+    // ray is advanced to the boundary of the current leaf node and the next, ready for the next iteration.
     while (true) {
       // Add small offset past the intersection to avoid
       // recursion to the same octree node!

--- a/chunky/src/java/se/llbit/math/NodeBasedOctree.java
+++ b/chunky/src/java/se/llbit/math/NodeBasedOctree.java
@@ -164,11 +164,12 @@ public class NodeBasedOctree implements Octree.OctreeImplementation {
     return lx == 0 && ly == 0 && lz == 0;
   }
 
+  // Moves the ray to the boundary of the octree. Returns false when the ray doesn't intersect the octree.
   private boolean enterOctree(Ray ray) {
     double nx = 0, ny = 0, nz = 0;
     double octree_size = 1 << depth;
 
-    // AABB intersection
+    // AABB intersection with the octree boundaries
     double tMin, tMax;
     double invDirX = 1 / ray.d.x;
     if (invDirX >= 0) {

--- a/chunky/src/java/se/llbit/math/NodeBasedOctree.java
+++ b/chunky/src/java/se/llbit/math/NodeBasedOctree.java
@@ -164,93 +164,97 @@ public class NodeBasedOctree implements Octree.OctreeImplementation {
     return lx == 0 && ly == 0 && lz == 0;
   }
 
+  private boolean enterOctree(Ray ray) {
+    double nx = 0, ny = 0, nz = 0;
+    double octree_size = 1 << depth;
+
+    // AABB intersection
+    double tMin, tMax;
+    double invDirX = 1 / ray.d.x;
+    if (invDirX >= 0) {
+      tMin = -ray.o.x * invDirX;
+      tMax = (octree_size - ray.o.x) * invDirX;
+
+      nx = -1;
+      ny = nz = 0;
+    } else {
+      tMin = (octree_size - ray.o.x) * invDirX;
+      tMax = -ray.o.x * invDirX;
+
+      nx = 1;
+      ny = nz = 0;
+    }
+
+    double tYMin, tYMax;
+    double invDirY = 1 / ray.d.y;
+    if (invDirY >= 0) {
+      tYMin = -ray.o.y * invDirY;
+      tYMax = (octree_size - ray.o.y) * invDirY;
+    } else {
+      tYMin = (octree_size - ray.o.y) * invDirY;
+      tYMax = -ray.o.y * invDirY;
+    }
+
+    if ((tMin > tYMax) || (tYMin > tMax))
+      return false;
+
+    if (tYMin > tMin) {
+      tMin = tYMin;
+
+      ny = -FastMath.signum(ray.d.y);
+      nx = nz = 0;
+    }
+
+    if (tYMax < tMax)
+      tMax = tYMax;
+
+    double tZMin, tZMax;
+    double invDirZ = 1 / ray.d.z;
+    if (invDirZ >= 0) {
+      tZMin = -ray.o.z * invDirZ;
+      tZMax = (octree_size - ray.o.z) * invDirZ;
+    } else {
+      tZMin = (octree_size - ray.o.z) * invDirZ;
+      tZMax = -ray.o.z * invDirZ;
+    }
+
+    if ((tMin > tZMax) || (tZMin > tMax))
+      return false;
+
+    if (tZMin > tMin) {
+      tMin = tZMin;
+
+      nz = -FastMath.signum(ray.d.y);
+      nx = ny = 0;
+    }
+
+    ray.o.scaleAdd(tMin, ray.d);
+    ray.n.set(nx, ny, nz);
+    ray.distance += tMin;
+    return true;
+  }
+
   @Override
   public boolean enterBlock(Scene scene, Ray ray, BlockPalette palette) {
-    int level;
-    Octree.Node node;
-    boolean first = true;
-
-    int lx, ly, lz;
-    int x, y, z;
-    int nx = 0, ny = 0, nz = 0;
-    double tNear = Double.POSITIVE_INFINITY;
-    double t;
-    Vector3 d = ray.d;
+    if (!isInside(ray.o) && !enterOctree(ray))
+      return false;
 
     while (true) {
-
       // Add small offset past the intersection to avoid
       // recursion to the same octree node!
-      x = (int) QuickMath.floor(ray.o.x + d.x * Ray.OFFSET);
-      y = (int) QuickMath.floor(ray.o.y + d.y * Ray.OFFSET);
-      z = (int) QuickMath.floor(ray.o.z + d.z * Ray.OFFSET);
+      int x = (int) QuickMath.floor(ray.o.x + ray.d.x * Ray.OFFSET);
+      int y = (int) QuickMath.floor(ray.o.y + ray.d.y * Ray.OFFSET);
+      int z = (int) QuickMath.floor(ray.o.z + ray.d.z * Ray.OFFSET);
 
-      node = root;
-      level = depth;
-      lx = x >>> level;
-      ly = y >>> level;
-      lz = z >>> level;
+      int lx = x >>> depth;
+      int ly = y >>> depth;
+      int lz = z >>> depth;
 
-      if (lx != 0 || ly != 0 || lz != 0) {
+      if (lx != 0 || ly != 0 || lz != 0)
+        return false; // outside of octree!
 
-        // ray origin is outside octree!
-
-        // only check octree intersection if this is the first iteration
-        if (first) {
-          // test if it is entering the octree
-          t = -ray.o.x / d.x;
-          if (t > Ray.EPSILON) {
-            tNear = t;
-            nx = 1;
-            ny = nz = 0;
-          }
-          t = ((1 << level) - ray.o.x) / d.x;
-          if (t < tNear && t > Ray.EPSILON) {
-            tNear = t;
-            nx = -1;
-            ny = nz = 0;
-          }
-          t = -ray.o.y / d.y;
-          if (t < tNear && t > Ray.EPSILON) {
-            tNear = t;
-            ny = 1;
-            nx = nz = 0;
-          }
-          t = ((1 << level) - ray.o.y) / d.y;
-          if (t < tNear && t > Ray.EPSILON) {
-            tNear = t;
-            ny = -1;
-            nx = nz = 0;
-          }
-          t = -ray.o.z / d.z;
-          if (t < tNear && t > Ray.EPSILON) {
-            tNear = t;
-            nz = 1;
-            nx = ny = 0;
-          }
-          t = ((1 << level) - ray.o.z) / d.z;
-          if (t < tNear && t > Ray.EPSILON) {
-            tNear = t;
-            nz = -1;
-            nx = ny = 0;
-          }
-
-          if (tNear < Double.MAX_VALUE) {
-            ray.o.scaleAdd(tNear, d);
-            ray.n.set(nx, ny, nz);
-            ray.distance += tNear;
-            tNear = Double.POSITIVE_INFINITY;
-            continue;
-          } else {
-            return false;// outside of octree!
-          }
-        } else {
-          return false;// outside of octree!
-        }
-      }
-
-      first = false;
-
+      Octree.Node node = root;
+      int level = depth;
       while (node.type == BRANCH_NODE) {
         level -= 1;
         lx = x >>> level;
@@ -284,13 +288,16 @@ public class NodeBasedOctree implements Octree.OctreeImplementation {
       }
 
       // Exit current octree leaf.
-      t = ((lx << level) - ray.o.x) / d.x;
+      int nx = 0, ny = 0, nz = 0;
+      double tNear = Double.POSITIVE_INFINITY;
+
+      double t = ((lx << level) - ray.o.x) / ray.d.x;
       if (t > Ray.EPSILON) {
         tNear = t;
         nx = 1;
         ny = nz = 0;
       } else {
-        t = (((lx + 1) << level) - ray.o.x) / d.x;
+        t = (((lx + 1) << level) - ray.o.x) / ray.d.x;
         if (t < tNear && t > Ray.EPSILON) {
           tNear = t;
           nx = -1;
@@ -298,13 +305,13 @@ public class NodeBasedOctree implements Octree.OctreeImplementation {
         }
       }
 
-      t = ((ly << level) - ray.o.y) / d.y;
+      t = ((ly << level) - ray.o.y) / ray.d.y;
       if (t < tNear && t > Ray.EPSILON) {
         tNear = t;
         ny = 1;
         nx = nz = 0;
       } else {
-        t = (((ly + 1) << level) - ray.o.y) / d.y;
+        t = (((ly + 1) << level) - ray.o.y) / ray.d.y;
         if (t < tNear && t > Ray.EPSILON) {
           tNear = t;
           ny = -1;
@@ -312,13 +319,13 @@ public class NodeBasedOctree implements Octree.OctreeImplementation {
         }
       }
 
-      t = ((lz << level) - ray.o.z) / d.z;
+      t = ((lz << level) - ray.o.z) / ray.d.z;
       if (t < tNear && t > Ray.EPSILON) {
         tNear = t;
         nz = 1;
         nx = ny = 0;
       } else {
-        t = (((lz + 1) << level) - ray.o.z) / d.z;
+        t = (((lz + 1) << level) - ray.o.z) / ray.d.z;
         if (t < tNear && t > Ray.EPSILON) {
           tNear = t;
           nz = -1;
@@ -326,10 +333,9 @@ public class NodeBasedOctree implements Octree.OctreeImplementation {
         }
       }
 
-      ray.o.scaleAdd(tNear, d);
+      ray.o.scaleAdd(tNear, ray.d);
       ray.n.set(nx, ny, nz);
       ray.distance += tNear;
-      tNear = Double.POSITIVE_INFINITY;
     }
   }
 

--- a/chunky/src/java/se/llbit/math/NodeBasedOctree.java
+++ b/chunky/src/java/se/llbit/math/NodeBasedOctree.java
@@ -166,7 +166,7 @@ public class NodeBasedOctree implements Octree.OctreeImplementation {
 
   // Moves the ray to the boundary of the octree. Returns false when the ray doesn't intersect the octree.
   private boolean enterOctree(Ray ray) {
-    double nx = 0, ny = 0, nz = 0;
+    double nx, ny, nz;
     double octree_size = 1 << depth;
 
     // AABB intersection with the octree boundaries
@@ -342,87 +342,23 @@ public class NodeBasedOctree implements Octree.OctreeImplementation {
 
   @Override
   public boolean exitWater(Scene scene, Ray ray, BlockPalette palette) {
-    int level;
-    Octree.Node node;
-    boolean first = true;
-
-    int lx, ly, lz;
-    int x, y, z;
-    int nx = 0, ny = 0, nz = 0;
-    double tNear = Double.POSITIVE_INFINITY;
-    double t;
-    Vector3 d = ray.d;
+    if (!isInside(ray.o) && !enterOctree(ray))
+      return false;
 
     while (true) {
+      int x = (int) QuickMath.floor(ray.o.x + ray.d.x * Ray.OFFSET);
+      int y = (int) QuickMath.floor(ray.o.y + ray.d.y * Ray.OFFSET);
+      int z = (int) QuickMath.floor(ray.o.z + ray.d.z * Ray.OFFSET);
 
-      x = (int) QuickMath.floor(ray.o.x + d.x * Ray.OFFSET);
-      y = (int) QuickMath.floor(ray.o.y + d.y * Ray.OFFSET);
-      z = (int) QuickMath.floor(ray.o.z + d.z * Ray.OFFSET);
+      int lx = x >>> depth;
+      int ly = y >>> depth;
+      int lz = z >>> depth;
 
-      node = root;
-      level = depth;
-      lx = x >>> level;
-      ly = y >>> level;
-      lz = z >>> level;
+      if (lx != 0 || ly != 0 || lz != 0)
+        return false;
 
-      if (lx != 0 || ly != 0 || lz != 0) {
-
-        // only check octree intersection if this is the first iteration
-        if (first) {
-          // test if it is entering the octree
-          t = -ray.o.x / d.x;
-          if (t > Ray.EPSILON) {
-            tNear = t;
-            nx = 1;
-            ny = nz = 0;
-          }
-          t = ((1 << level) - ray.o.x) / d.x;
-          if (t < tNear && t > Ray.EPSILON) {
-            tNear = t;
-            nx = -1;
-            ny = nz = 0;
-          }
-          t = -ray.o.y / d.y;
-          if (t < tNear && t > Ray.EPSILON) {
-            tNear = t;
-            ny = 1;
-            nx = nz = 0;
-          }
-          t = ((1 << level) - ray.o.y) / d.y;
-          if (t < tNear && t > Ray.EPSILON) {
-            tNear = t;
-            ny = -1;
-            nx = nz = 0;
-          }
-          t = -ray.o.z / d.z;
-          if (t < tNear && t > Ray.EPSILON) {
-            tNear = t;
-            nz = 1;
-            nx = ny = 0;
-          }
-          t = ((1 << level) - ray.o.z) / d.z;
-          if (t < tNear && t > Ray.EPSILON) {
-            tNear = t;
-            nz = -1;
-            nx = ny = 0;
-          }
-
-          if (tNear < Double.MAX_VALUE) {
-            ray.o.scaleAdd(tNear, d);
-            ray.n.set(nx, ny, nz);
-            ray.distance += tNear;
-            tNear = Double.POSITIVE_INFINITY;
-            continue;
-          } else {
-            return false;// outside of octree!
-          }
-        } else {
-          return false;// outside of octree!
-        }
-      }
-
-      first = false;
-
+      Octree.Node node = root;
+      int level = depth;
       while (node.type == BRANCH_NODE) {
         level -= 1;
         lx = x >>> level;
@@ -462,13 +398,16 @@ public class NodeBasedOctree implements Octree.OctreeImplementation {
         }
       }
 
-      t = ((lx << level) - ray.o.x) / d.x;
+      double nx = 0, ny = 0, nz = 0;
+      double tNear = Double.POSITIVE_INFINITY;
+
+      double t = ((lx << level) - ray.o.x) / ray.d.x;
       if (t > Ray.EPSILON) {
         tNear = t;
         nx = 1;
         ny = nz = 0;
       } else {
-        t = (((lx + 1) << level) - ray.o.x) / d.x;
+        t = (((lx + 1) << level) - ray.o.x) / ray.d.x;
         if (t < tNear && t > Ray.EPSILON) {
           tNear = t;
           nx = -1;
@@ -476,13 +415,13 @@ public class NodeBasedOctree implements Octree.OctreeImplementation {
         }
       }
 
-      t = ((ly << level) - ray.o.y) / d.y;
+      t = ((ly << level) - ray.o.y) / ray.d.y;
       if (t < tNear && t > Ray.EPSILON) {
         tNear = t;
         ny = 1;
         nx = nz = 0;
       } else {
-        t = (((ly + 1) << level) - ray.o.y) / d.y;
+        t = (((ly + 1) << level) - ray.o.y) / ray.d.y;
         if (t < tNear && t > Ray.EPSILON) {
           tNear = t;
           ny = -1;
@@ -490,13 +429,13 @@ public class NodeBasedOctree implements Octree.OctreeImplementation {
         }
       }
 
-      t = ((lz << level) - ray.o.z) / d.z;
+      t = ((lz << level) - ray.o.z) / ray.d.z;
       if (t < tNear && t > Ray.EPSILON) {
         tNear = t;
         nz = 1;
         nx = ny = 0;
       } else {
-        t = (((lz + 1) << level) - ray.o.z) / d.z;
+        t = (((lz + 1) << level) - ray.o.z) / ray.d.z;
         if (t < tNear && t > Ray.EPSILON) {
           tNear = t;
           nz = -1;
@@ -504,10 +443,9 @@ public class NodeBasedOctree implements Octree.OctreeImplementation {
         }
       }
 
-      ray.o.scaleAdd(tNear, d);
+      ray.o.scaleAdd(tNear, ray.d);
       ray.n.set(nx, ny, nz);
       ray.distance += tNear;
-      tNear = Double.POSITIVE_INFINITY;
     }
   }
 

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -47,7 +47,19 @@ public class Octree {
     Material getMaterial(int x, int y, int z, BlockPalette palette);
     void store(DataOutputStream output) throws IOException;
     boolean isInside(Vector3 pos);
+
+    /**
+     * Intersects the ray with the geometry inside the octree.
+     *
+     * @return {@code false} if the ray did not hit the geometry
+     */
     boolean enterBlock(Scene scene, Ray ray, BlockPalette palette);
+
+    /**
+     * Advance the ray until it leaves the current water body.
+     *
+     * @return {@code false} if the ray doesn't hit anything
+     */
     boolean exitWater(Scene scene, Ray ray, BlockPalette palette);
     int getDepth();
   }

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -327,6 +327,10 @@ public class Octree {
     return implementation.isInside(o);
   }
 
+  /**
+   * Advance the ray until it intersects with the geometry inside the octree
+   * @return {@code false} if the ray didn't intersect
+   */
   public boolean enterBlock(Scene scene, Ray ray, BlockPalette palette) {
     return implementation.enterBlock(scene, ray, palette);
   }

--- a/chunky/src/java/se/llbit/math/PackedOctree.java
+++ b/chunky/src/java/se/llbit/math/PackedOctree.java
@@ -369,7 +369,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
   }
 
   /**
-   * Moves the ray to the of the octree.
+   * Moves the ray to the boundary of the octree.
    * @param ray Ray that will be moved to the boundary of the octree. The origin, distance and normals will be modified.
    * @return {@code false} if the ray doesn't intersect the octree.
    */

--- a/chunky/src/java/se/llbit/math/PackedOctree.java
+++ b/chunky/src/java/se/llbit/math/PackedOctree.java
@@ -446,11 +446,17 @@ public class PackedOctree implements Octree.OctreeImplementation {
     return true;
   }
 
+  /**
+   *  {@inheritDoc}
+   */
   @Override
   public boolean enterBlock(Scene scene, Ray ray, BlockPalette palette) {
     if (!isInside(ray.o) && !enterOctree(ray))
       return false;
 
+    // Marching is done in a top-down fashion: at each step, the octree is descended from the root to find the leaf
+    // node the ray is in. Terminating the march is then decided based on the block type in that leaf node. Finally the
+    // ray is advanced to the boundary of the current leaf node and the next, ready for the next iteration.
     while (true) {
       // Add small offset past the intersection to avoid
       // recursion to the same octree node!
@@ -554,11 +560,17 @@ public class PackedOctree implements Octree.OctreeImplementation {
     }
   }
 
+  /**
+   *  {@inheritDoc}
+   */
   @Override
   public boolean exitWater(Scene scene, Ray ray, BlockPalette palette) {
     if (!isInside(ray.o) && !enterOctree(ray))
       return false;
 
+    // Marching is done in a top-down fashion: at each step, the octree is descended from the root to find the leaf
+    // node the ray is in. Terminating the march is then decided based on the block type in that leaf node. Finally the
+    // ray is advanced to the boundary of the current leaf node and the next, ready for the next iteration.
     while (true) {
       // Add small offset past the intersection to avoid
       // recursion to the same octree node!

--- a/chunky/src/java/se/llbit/math/PackedOctree.java
+++ b/chunky/src/java/se/llbit/math/PackedOctree.java
@@ -428,9 +428,12 @@ public class PackedOctree implements Octree.OctreeImplementation {
     if (tZMin > tMin) {
       tMin = tZMin;
 
-      nz = -FastMath.signum(ray.d.y);
+      nz = -FastMath.signum(ray.d.z);
       nx = ny = 0;
     }
+
+    if (tMin < 0)
+      return false;
 
     ray.o.scaleAdd(tMin, ray.d);
     ray.n.set(nx, ny, nz);

--- a/chunky/src/java/se/llbit/math/PackedOctree.java
+++ b/chunky/src/java/se/llbit/math/PackedOctree.java
@@ -368,11 +368,12 @@ public class PackedOctree implements Octree.OctreeImplementation {
     return lx == 0 && ly == 0 && lz == 0;
   }
 
+  // Moves the ray to the boundary of the octree. Returns false when the ray doesn't intersect the octree.
   private boolean enterOctree(Ray ray) {
     double nx = 0, ny = 0, nz = 0;
     double octree_size = 1 << depth;
 
-    // AABB intersection
+    // AABB intersection with the octree boundaries
     double tMin, tMax;
     double invDirX = 1 / ray.d.x;
     if (invDirX >= 0) {


### PR DESCRIPTION
In the octree intersection functions, the initialization (moving the ray to the boundary of the octree if it is outside) is done in the first iterations of the traversal loop.

* This refactor changes the initialization to directly intersect the octree's bounding box instead of marching to it in several iterations. It also moves it outside of the loop and into its own function `enterOctree(Ray ray)`. On top of making the code more readable it removes some iterations and some branching in a hot loop (though I saw no noticeable performance improvements).
* Variable declarations were also moved to more appropriate locations instead of having them all at the beginning of the function.

The initialization part could be reduced to a simple `AABB.intersect` ideally, but the `AABB` class has been implemented such that the bounding box must be contained within a block and wraps the ray origin to said block, certainly for use with models (despite the doc comments saying it could be used for Bounding Volume Hierarchies).

Related to #612 