### PR TITLE
Add support for surrogate characters in the JSON font loader.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/resources/SignTexture.java
+++ b/chunky/src/java/se/llbit/chunky/resources/SignTexture.java
@@ -56,8 +56,7 @@ public class SignTexture extends Texture {
       int lineWidth = 0;
       for (JsonValue textItem : line) {
         String textLine = textItem.object().get("text").stringValue("");
-        for (int j = 0; j < textLine.length(); ++j) {
-          char c = textLine.charAt(j);
+        for (int c : textLine.codePoints().toArray()) {
           Glyph glyph = Texture.fonts.getGlyph(c);
           lineWidth += glyph != null ? glyph.width : 0;
         }
@@ -67,8 +66,7 @@ public class SignTexture extends Texture {
         String textLine = textItem.object().get("text").stringValue("");
         Color color = Color.get(textItem.object().get("color").intValue(0));
 
-        for (int j = 0; j < textLine.length(); ++j) {
-          char c = textLine.charAt(j);
+        for (int c : textLine.codePoints().toArray()) {
           Glyph glyph = Texture.fonts.getGlyph(c);
           if (glyph != null) {
             int y = ystart - glyph.ascent + lineHeight;

--- a/chunky/src/java/se/llbit/chunky/resources/texturepack/FontTexture.java
+++ b/chunky/src/java/se/llbit/chunky/resources/texturepack/FontTexture.java
@@ -29,26 +29,39 @@ public class FontTexture {
     }
   }
 
-  private Map<Character, Glyph> glyphs = new HashMap<>();
+  /** Maps code points to glyphs */
+  private Map<Integer, Glyph> glyphs = new HashMap<>();
 
-  public Glyph getGlyph(char c) {
-    return glyphs.get(c);
+  public Glyph getGlyph(int codePoint) {
+    return glyphs.get(codePoint);
   }
 
-  public void setGlyph(char c, Glyph glyph) {
-    glyphs.put(c, glyph);
+  public void setGlyph(int codePoint, Glyph glyph) {
+    glyphs.put(codePoint, glyph);
   }
 
-  public boolean containsGlyph(char c) {
-    return glyphs.containsKey(c);
+  public boolean containsGlyph(int codePoint) {
+    return glyphs.containsKey(codePoint);
   }
 
   public void clear() {
     glyphs.clear();
   }
 
+  /**
+   * Load a glyph from a spritemap where all glyphs have the same dimensions.
+   *
+   * @param spritemap Spritemap
+   * @param x0 Column of the glyph
+   * @param y0 Row of the glyph
+   * @param codePoint Code point the glyph corresponds to
+   * @param width Width of the glyphs, in pixels
+   * @param height Height of the glyphs, in pixels
+   * @param ascent The number of pixels to move the glyph up in the line, used e.g. for accents on
+   *     capital letters
+   */
   void loadGlyph(
-      BitmapImage spritemap, int x0, int y0, char ch, int width, int height, int ascent) {
+      BitmapImage spritemap, int x0, int y0, int codePoint, int width, int height, int ascent) {
     int xmin = width;
     int xmax = 0;
     int[] lines = new int[height];
@@ -66,6 +79,6 @@ public class FontTexture {
         }
       }
     }
-    setGlyph(ch, new Glyph(lines, xmin, xmax, width, height, ascent));
+    setGlyph(codePoint, new Glyph(lines, xmin, xmax, width, height, ascent));
   }
 }

--- a/chunky/src/java/se/llbit/chunky/resources/texturepack/JsonFontTextureLoader.java
+++ b/chunky/src/java/se/llbit/chunky/resources/texturepack/JsonFontTextureLoader.java
@@ -96,9 +96,9 @@ public class JsonFontTextureLoader extends TextureLoader {
       int x, y = 0;
       for (JsonValue charactersLine : fontDefinition.asObject().get("chars").asArray()) {
         x = 0;
-        for (char character : charactersLine.stringValue("").toCharArray()) {
-          if (!Texture.fonts.containsGlyph(character)) {
-            Texture.fonts.loadGlyph(spritemap, x, y, character, width, height, ascent);
+        for (int codePoint : charactersLine.stringValue("").codePoints().toArray()) {
+          if (!Texture.fonts.containsGlyph(codePoint)) {
+            Texture.fonts.loadGlyph(spritemap, x, y, codePoint, width, height, ascent);
           }
           x++;
         }


### PR DESCRIPTION
[Minecraft 1.16-pre7 added new font characters](https://minecraft.gamepedia.com/Java_Edition_1.16_Pre-release_7) that caused loading the JSON font definitions to fail.

This PR adds support for surrogate characters so that the new characters can be loaded and rendered properly:
![image](https://user-images.githubusercontent.com/5544859/85185629-12975400-b295-11ea-9a9c-d7ab72ab0892.png)


