### PR TITLE
Fix water bug under vine

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/Vine.java
+++ b/chunky/src/java/se/llbit/chunky/block/Vine.java
@@ -37,6 +37,8 @@ public class Vine extends MinecraftBlockTranslucent {
       connections = BlockData.CONNECTED_SOUTH;
     }
     this.connections = connections;
+
+    this.solid = false;
   }
 
   @Override public boolean intersect(Ray ray, Scene scene) {


### PR DESCRIPTION
Fix the bug where water blocks are rendered as full blocks when under a vine

before:
![water-vine-bug](https://user-images.githubusercontent.com/23342398/85236329-5c12ab00-b41d-11ea-88ef-4cea5f5a9137.png)

after:
![water-vine-working](https://user-images.githubusercontent.com/23342398/85236334-62088c00-b41d-11ea-8c74-c9c22f2c8dc7.png)

