### PR TITLE
Fix Chunky not exiting in headless mode

### DIFF
--- a/chunky/src/java/se/llbit/chunky/main/Chunky.java
+++ b/chunky/src/java/se/llbit/chunky/main/Chunky.java
@@ -310,7 +310,7 @@ public class Chunky {
             System.out.println("Image output mode: TIFF32");
             break;
         }
-        scene.saveFrame(new File(options.imageOutputFile), taskTracker, getRenderContext().numRenderThreads());
+        scene.saveFrame(new File(options.imageOutputFile), taskTracker, context.numRenderThreads());
         System.out.println("Saved snapshot to " + options.imageOutputFile);
         return 0;
       }

--- a/chunky/src/java/se/llbit/chunky/main/Chunky.java
+++ b/chunky/src/java/se/llbit/chunky/main/Chunky.java
@@ -122,6 +122,7 @@ public class Chunky {
     Renderer renderer = rendererFactory.newRenderer(context, true);
     SynchronousSceneManager sceneManager = new SynchronousSceneManager(context, renderer);
     renderer.setSceneProvider(sceneManager);
+    renderController = new RenderController(context, renderer, sceneManager, sceneManager);
     TaskTracker taskTracker = new TaskTracker(new ConsoleProgressListener(),
         (tracker, previous, name, size) -> new TaskTracker.Task(tracker, previous, name, size) {
           @Override


### PR DESCRIPTION
This fixes Chunky not exiting after headless rendering or snapshot creation (`-render` or `-snapshot` CLI options).

Turns out that a call to getRenderController() in headless Chunky creates a new RenderController with a new scene manager, context and worker threads. To solve this, the headless renderer now initializes the `renderController` properly and the snapshot code makes sure not to use the render controller (it doesn't use any of the factories either).