### PR TITLE
Use the settings when loading a scene with no octree implementation specified

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -2566,7 +2566,7 @@ public class Scene implements JsonSerializable, Refreshable {
       }
     }
 
-    octreeImplementation = json.get("octreeImplementation").asString(Octree.DEFAULT_IMPLEMENTATION);
+    octreeImplementation = json.get("octreeImplementation").asString(PersistentSettings.getOctreeImplementation());
   }
 
   /**

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -242,6 +242,7 @@ public class Octree {
    * @param octreeDepth The number of levels in the Octree.
    */
   public Octree(String impl, int octreeDepth) {
+    Log.infof("Building new octree (%s)", impl);
     implementation = getImplementationFactory(impl).create(octreeDepth);
   }
 
@@ -316,6 +317,7 @@ public class Octree {
    * @throws IOException
    */
   public static Octree load(String impl, DataInputStream in) throws IOException {
+    Log.infof("Loading octree (%s)", impl);
     return new Octree(getImplementationFactory(impl).load(in));
   }
 
@@ -686,6 +688,8 @@ public class Octree {
       // Already correct implementation
       return;
     }
+
+    Log.infof("Changing octree implementation (%s)", newImplementation);
 
     // This function is called as to provide a fallback when
     // an implementation isn't suitable, we assume it means

--- a/chunky/src/java/se/llbit/math/PackedOctree.java
+++ b/chunky/src/java/se/llbit/math/PackedOctree.java
@@ -407,36 +407,6 @@ public class PackedOctree implements Octree.OctreeImplementation {
     }
   }
 
-  /**
-   * Convert this tree to the equivalent NodeBasedOctree
-   * @return The NodeBasedOctree
-   */
-  public NodeBasedOctree toNodeBasedOctree() {
-    return new NodeBasedOctree(depth, convertNode(0));
-  }
-
-  /**
-   * Convert a node to the NodeBasedOctree node format
-   * @param nodeIndex The index of the node to convert
-   * @return The converted node
-   */
-  private Octree.Node convertNode(int nodeIndex) {
-    if(treeData[nodeIndex] > 0) {
-      // branch node
-      Octree.Node node = new Octree.Node(BRANCH_NODE);
-      node.children = new Octree.Node[8];
-      for(int i = 0; i < 8; ++i) {
-        int childIndex = treeData[nodeIndex] + 2*i;
-        node.children[i] = convertNode(childIndex);
-      }
-      return node;
-    } else {
-      boolean isDataNode = (treeData[nodeIndex+1] != 0);
-      return isDataNode ? new Octree.DataNode(treeData[nodeIndex], treeData[nodeIndex+1])
-                        : new Octree.Node(treeData[nodeIndex]);
-    }
-  }
-
   @Override
   public long nodeCount() {
     return countNodes(0);


### PR DESCRIPTION
There was a bug where, when a scene json file didn't have an octree implementation specified, it used the packed octree instead of using the one specified in persistent settings. This PR fixes that.
I also removed a function that is now useless that I forgot to remove before