### PR TITLE
Memory usage reduction

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/Water.java
+++ b/chunky/src/java/se/llbit/chunky/block/Water.java
@@ -82,9 +82,6 @@ public class Water extends MinecraftBlockTranslucent {
       14 / 16., 12.25 / 16., 10.5 / 16, 8.75 / 16, 7. / 16, 5.25 / 16, 3.5 / 16, 1.75 / 16
   };
 
-  private static final float[][][] normalMap;
-  private static final int normalMapW;
-
   /**
    * Block data offset for water above flag.
    */
@@ -95,22 +92,6 @@ public class Water extends MinecraftBlockTranslucent {
   public static final int CORNER_3 = 12;
 
   static {
-    // Precompute normal map.
-    Texture waterHeight = new Texture("water-height");
-    normalMapW = waterHeight.getWidth();
-    normalMap = new float[normalMapW][normalMapW][2];
-    for (int u = 0; u < normalMapW; ++u) {
-      for (int v = 0; v < normalMapW; ++v) {
-
-        float hx0 = (waterHeight.getColorWrapped(u, v) & 0xFF) / 255.f;
-        float hx1 = (waterHeight.getColorWrapped(u + 1, v) & 0xFF) / 255.f;
-        float hz0 = (waterHeight.getColorWrapped(u, v) & 0xFF) / 255.f;
-        float hz1 = (waterHeight.getColorWrapped(u, v + 1) & 0xFF) / 255.f;
-        normalMap[u][v][0] = hx1 - hx0;
-        normalMap[u][v][1] = hz1 - hz0;
-      }
-    }
-
     // Precompute water triangles.
     for (int i = 0; i < 8; ++i) {
       double c0 = height[i];

--- a/chunky/src/java/se/llbit/chunky/model/WaterModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/WaterModel.java
@@ -73,7 +73,7 @@ public class WaterModel {
   static final double height[] =
       {14 / 16., 12.25 / 16., 10.5 / 16, 8.75 / 16, 7. / 16, 5.25 / 16, 3.5 / 16, 1.75 / 16};
 
-  private static final float[][][] normalMap;
+  private static final float[] normalMap;
   private static final int normalMapW;
 
   /**
@@ -85,7 +85,7 @@ public class WaterModel {
     // precompute normal map
     Texture waterHeight = new Texture("water-height");
     normalMapW = waterHeight.getWidth();
-    normalMap = new float[normalMapW][normalMapW][2];
+    normalMap = new float[normalMapW*normalMapW*2];
     for (int u = 0; u < normalMapW; ++u) {
       for (int v = 0; v < normalMapW; ++v) {
 
@@ -93,8 +93,8 @@ public class WaterModel {
         float hx1 = (waterHeight.getColorWrapped(u + 1, v) & 0xFF) / 255.f;
         float hz0 = (waterHeight.getColorWrapped(u, v) & 0xFF) / 255.f;
         float hz1 = (waterHeight.getColorWrapped(u, v + 1) & 0xFF) / 255.f;
-        normalMap[u][v][0] = hx1 - hx0;
-        normalMap[u][v][1] = hz1 - hz0;
+        normalMap[(u*normalMapW + v) * 2] = hx1 - hx0;
+        normalMap[(u*normalMapW + v) * 2 + 1] = hz1 - hz0;
       }
     }
 
@@ -341,14 +341,14 @@ public class WaterModel {
     double z = ray.o.z / w - QuickMath.floor(ray.o.z / w);
     int u = (int) (x * normalMapW - Ray.EPSILON);
     int v = (int) ((1 - z) * normalMapW - Ray.EPSILON);
-    ray.n.set(normalMap[u][v][0], .15f, normalMap[u][v][1]);
+    ray.n.set(normalMap[(u*normalMapW + v) * 2], .15f, normalMap[(u*normalMapW + v) * 2 + 1]);
     w = (1 << 1);
     x = ray.o.x / w - QuickMath.floor(ray.o.x / w);
     z = ray.o.z / w - QuickMath.floor(ray.o.z / w);
     u = (int) (x * normalMapW - Ray.EPSILON);
     v = (int) ((1 - z) * normalMapW - Ray.EPSILON);
-    ray.n.x += normalMap[u][v][0] / 2;
-    ray.n.z += normalMap[u][v][1] / 2;
+    ray.n.x += normalMap[(u*normalMapW + v) * 2] / 2;
+    ray.n.z += normalMap[(u*normalMapW + v) * 2 + 1] / 2;
     ray.n.normalize();
   }
 }

--- a/chunky/src/java/se/llbit/chunky/world/ChunkTexture.java
+++ b/chunky/src/java/se/llbit/chunky/world/ChunkTexture.java
@@ -27,7 +27,7 @@ import java.io.IOException;
  */
 public class ChunkTexture {
 
-  float[][] data = new float[Chunk.X_MAX * Chunk.Z_MAX][3];
+  float[] data = new float[Chunk.X_MAX * Chunk.Z_MAX * 3];
 
   /**
    * Create new texture
@@ -42,17 +42,19 @@ public class ChunkTexture {
    */
   public void set(int x, int z, float[] frgb) {
     int index = x + z * Chunk.X_MAX;
-    data[index][0] = frgb[0];
-    data[index][1] = frgb[1];
-    data[index][2] = frgb[2];
+    data[index*3] = frgb[0];
+    data[index*3 + 1] = frgb[1];
+    data[index*3 + 2] = frgb[2];
   }
 
   /**
    * @return RGB color components at (x, z)
    */
   public float[] get(int x, int z) {
+    float[] result = new float[3];
     int index = x + z * Chunk.X_MAX;
-    return data[index];
+    System.arraycopy(data, index*3, result, 0, 3);
+    return result;
   }
 
   /**
@@ -62,9 +64,9 @@ public class ChunkTexture {
    */
   public void store(DataOutputStream out) throws IOException {
     for (int i = 0; i < Chunk.X_MAX * Chunk.Z_MAX; ++i) {
-      out.writeFloat(data[i][0]);
-      out.writeFloat(data[i][1]);
-      out.writeFloat(data[i][2]);
+      out.writeFloat(data[i*30]);
+      out.writeFloat(data[i*3 + 1]);
+      out.writeFloat(data[i*3 + 2]);
     }
   }
 
@@ -77,9 +79,9 @@ public class ChunkTexture {
   public static ChunkTexture load(DataInputStream in) throws IOException {
     ChunkTexture texture = new ChunkTexture();
     for (int i = 0; i < Chunk.X_MAX * Chunk.Z_MAX; ++i) {
-      texture.data[i][0] = in.readFloat();
-      texture.data[i][1] = in.readFloat();
-      texture.data[i][2] = in.readFloat();
+      texture.data[i*3] = in.readFloat();
+      texture.data[i*3 + 1] = in.readFloat();
+      texture.data[i*3 + 2] = in.readFloat();
     }
     return texture;
   }


### PR DESCRIPTION
I made some changes to get some free memory usage reduction by flattening some arrays here and there (and removing a copy of the water normal that was loaded twice)
I measured a 100MB memory usage reduction on the scene i tried but it most likely isn't proportional to the scene size as I mostly changed code about the textures (the change on chunk texture could scale with size of the scene)