### PR TITLE
Fix error in chunk texture

### DIFF
--- a/chunky/src/java/se/llbit/chunky/world/ChunkTexture.java
+++ b/chunky/src/java/se/llbit/chunky/world/ChunkTexture.java
@@ -64,7 +64,7 @@ public class ChunkTexture {
    */
   public void store(DataOutputStream out) throws IOException {
     for (int i = 0; i < Chunk.X_MAX * Chunk.Z_MAX; ++i) {
-      out.writeFloat(data[i*30]);
+      out.writeFloat(data[i*3]);
       out.writeFloat(data[i*3 + 1]);
       out.writeFloat(data[i*3 + 2]);
     }


### PR DESCRIPTION
I made a small typo in #631 that make storing chunk texture reading the wrong float (and maybe triggering an IndexOutOfBoundsException), this fixes it