### PR TITLE
Fix jello water when cause by interaction between water plane and normal water

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
@@ -89,12 +89,12 @@ public class PreviewRayTracer implements RayTracer {
     if (scene.sky().cloudsEnabled()) {
       hit = scene.sky().cloudIntersection(scene, ray);
     }
-    if (scene.waterHeight > 0) {
-      hit = waterIntersection(scene, ray) || hit;
-    }
     if (scene.intersect(ray)) {
       // Octree tracer handles updating distance.
       return true;
+    }
+    if (scene.waterHeight > 0) {
+      hit = waterIntersection(scene, ray) || hit;
     }
     if (hit) {
       ray.distance += ray.t;

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
@@ -89,12 +89,12 @@ public class PreviewRayTracer implements RayTracer {
     if (scene.sky().cloudsEnabled()) {
       hit = scene.sky().cloudIntersection(scene, ray);
     }
+    if (scene.waterHeight > 0) {
+      hit = waterIntersection(scene, ray) || hit;
+    }
     if (scene.intersect(ray)) {
       // Octree tracer handles updating distance.
       return true;
-    }
-    if (scene.waterHeight > 0) {
-      hit = waterIntersection(scene, ray) || hit;
     }
     if (hit) {
       ray.distance += ray.t;
@@ -111,8 +111,6 @@ public class PreviewRayTracer implements RayTracer {
     if (ray.d.y < 0) {
       double t = (scene.waterHeight - .125 - ray.o.y - scene.origin.y) / ray.d.y;
       if (t > 0 && t < ray.t) {
-        Vector3 vec = new Vector3();
-        vec.scaleAdd(t + Ray.OFFSET, ray.d, ray.o);
         ray.t = t;
         Water.INSTANCE.getColor(ray);
         ray.n.set(0, 1, 0);
@@ -123,8 +121,6 @@ public class PreviewRayTracer implements RayTracer {
     if (ray.d.y > 0) {
       double t = (scene.waterHeight - .125 - ray.o.y - scene.origin.y) / ray.d.y;
       if (t > 0 && t < ray.t) {
-        Vector3 vec = new Vector3();
-        vec.scaleAdd(t + Ray.OFFSET, ray.d, ray.o);
         ray.t = t;
         Water.INSTANCE.getColor(ray);
         ray.n.set(0, -1, 0);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -643,16 +643,18 @@ public class Scene implements JsonSerializable, Refreshable {
       ray.setCurrentMaterial(r.getCurrentMaterial(), r.getCurrentData());
       hit = true;
     }
-    if (start.getCurrentMaterial().isWater() && start.getCurrentMaterial() != Water.OCEAN_WATER) {
-      r = new Ray(start);
-      r.setCurrentMaterial(start.getPrevMaterial(), start.getPrevData());
-      if (waterOctree.exitWater(this, r, palette) && r.distance < ray.t - Ray.EPSILON) {
-        ray.t = r.distance;
-        ray.n.set(r.n);
-        ray.color.set(r.color);
-        ray.setPrevMaterial(r.getPrevMaterial(), r.getPrevData());
-        ray.setCurrentMaterial(r.getCurrentMaterial(), r.getCurrentData());
-        hit = true;
+    if (start.getCurrentMaterial().isWater()) {
+      if(start.getCurrentMaterial() != Water.OCEAN_WATER) {
+        r = new Ray(start);
+        r.setCurrentMaterial(start.getPrevMaterial(), start.getPrevData());
+        if(waterOctree.exitWater(this, r, palette) && r.distance < ray.t - Ray.EPSILON) {
+          ray.t = r.distance;
+          ray.n.set(r.n);
+          ray.color.set(r.color);
+          ray.setPrevMaterial(r.getPrevMaterial(), r.getPrevData());
+          ray.setCurrentMaterial(r.getCurrentMaterial(), r.getCurrentData());
+          hit = true;
+        }
       }
     } else {
       r = new Ray(start);


### PR DESCRIPTION
Before:
![water-plane-before-change](https://user-images.githubusercontent.com/23342398/87681923-871fbe80-c77f-11ea-98c0-c18cb07ef917.png)

After:
![same-level-new-fix](https://user-images.githubusercontent.com/23342398/87695114-63647480-c78f-11ea-9720-9ee1e904e501.png)

This was caused by trying to enter the water in the octree when the ray already entered the water of the water plane