### PR TITLE
Fix underwater emitter issue

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -654,6 +654,8 @@ public class Scene implements JsonSerializable, Refreshable {
           ray.setPrevMaterial(r.getPrevMaterial(), r.getPrevData());
           ray.setCurrentMaterial(r.getCurrentMaterial(), r.getCurrentData());
           hit = true;
+        } else if(ray.getPrevMaterial() == Air.INSTANCE) {
+          ray.setPrevMaterial(Water.INSTANCE, 1 << Water.FULL_BLOCK);
         }
       }
     } else {


### PR DESCRIPTION
While stepping into the path tracing code, i saw that a ray had its previous material set as air even though it was in water, so i added a test to set its previous material to water. I don't really understand why but it fixes the issue with underwater emitters not lighting the block around.
Fixes #528 

Render with fix:
![image](https://user-images.githubusercontent.com/23342398/87740777-570a0700-c7e3-11ea-9ff8-c91933220123.png)
