### PR TITLE
Octree finalization optimization

### DIFF
--- a/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
+++ b/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
@@ -26,7 +26,7 @@ import java.util.function.Consumer;
 public class BlockPalette {
   private static final int BLOCK_PALETTE_VERSION = 4;
   public final int airId, stoneId, waterId;
-  public static final int WHATEVER_ID = Octree.WHATEVER_TYPE;
+  public static final int ANY_ID = Octree.ANY_TYPE;
 
   private final Map<String, Consumer<Block>> materialProperties;
 
@@ -81,7 +81,7 @@ public class BlockPalette {
   }
 
   public Block get(int id) {
-    if(id == WHATEVER_ID)
+    if(id == ANY_ID)
       return stone;
     return palette.get(id);
   }

--- a/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
+++ b/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
@@ -1,6 +1,7 @@
 package se.llbit.chunky.chunk;
 
 import se.llbit.chunky.block.*;
+import se.llbit.math.Octree;
 import se.llbit.nbt.CompoundTag;
 import se.llbit.nbt.StringTag;
 import se.llbit.nbt.Tag;
@@ -25,6 +26,7 @@ import java.util.function.Consumer;
 public class BlockPalette {
   private static final int BLOCK_PALETTE_VERSION = 4;
   public final int airId, stoneId, waterId;
+  public static final int WHATEVER_ID = Octree.WHATEVER_TYPE;
 
   private final Map<String, Consumer<Block>> materialProperties;
 
@@ -79,6 +81,8 @@ public class BlockPalette {
   }
 
   public Block get(int id) {
+    if(id == WHATEVER_ID)
+      return stone;
     return palette.get(id);
   }
 

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/OctreeFinalizer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/OctreeFinalizer.java
@@ -59,7 +59,7 @@ public class OctreeFinalizer {
 
   private static void hideBlocks(Octree worldTree, BlockPalette palette, int x,
                                  int cy, int z, int yMin, int yMax, Vector3i origin) {
-    // Set non-visible blocks to be stone, in order to merge large patches.
+    // Set non-visible blocks to be any block, in order to merge large patches.
     int y = cy - origin.y;
     if (cy > yMin && cy < yMax - 1) {
       boolean isHidden =
@@ -70,7 +70,7 @@ public class OctreeFinalizer {
               && worldTree.getMaterial(x, y - 1, z, palette).opaque
               && worldTree.getMaterial(x, y + 1, z, palette).opaque;
       if (isHidden) {
-        worldTree.set(BlockPalette.WHATEVER_ID, x, y, z);
+        worldTree.set(BlockPalette.ANY_ID, x, y, z);
       }
     }
   }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/OctreeFinalizer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/OctreeFinalizer.java
@@ -47,11 +47,10 @@ public class OctreeFinalizer {
         int z = cz + cp.z * 16 - origin.z;
         for (int cx = 0; cx < 16; ++cx) {
           int x = cx + cp.x * 16 - origin.x;
-          processBlock(worldTree, waterTree, palette, x, cy, z);
-
-          // only call hideBlocks for blocks on the edges of the chunk
+          // process blocks that are at the edge of the chunk, the other should have be taken care of during th loading
           if(cy == yMin || cy == yMax-1 || cz == 0 || cz == 15 || cx == 0 || cx == 15) {
             hideBlocks(worldTree, palette, x, cy, z, yMin, yMax, origin);
+            processBlock(worldTree, waterTree, palette, x, cy, z);
           }
         }
       }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/OctreeFinalizer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/OctreeFinalizer.java
@@ -59,7 +59,7 @@ public class OctreeFinalizer {
     Material wmat = waterTree.getMaterial(x, cy, z, palette);
 
     // Set non-visible blocks to be stone, in order to merge large patches.
-    if (cy > -origin.y && cy < Chunk.Y_MAX - origin.y - 1 && worldTree.get(x, cy, z).type != palette.stoneId) {
+    if (cy > -origin.y && cy < Chunk.Y_MAX - origin.y - 1) {
       Material b1 = worldTree.getMaterial(x - 1, cy, z, palette),
           b2 = worldTree.getMaterial(x + 1, cy, z, palette),
           b3 = worldTree.getMaterial(x, cy, z - 1, palette),
@@ -68,7 +68,7 @@ public class OctreeFinalizer {
           b6 = worldTree.getMaterial(x, cy + 1, z, palette);
 
       if (b1.opaque && b2.opaque && b3.opaque && b4.opaque && b5.opaque && b6.opaque) {
-        worldTree.set(palette.stoneId, x, cy, z);
+        worldTree.set(BlockPalette.WHATEVER_ID, x, cy, z);
       }
     }
 

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -852,7 +852,7 @@ public class Scene implements JsonSerializable, Refreshable {
               int x = cx + cp.x * 16 - origin.x;
               int index = Chunk.chunkIndex(cx, cy, cz);
 
-              // Check if the block is hidden, if so make it "whatever"
+              // Change the type of hidden blocks to ANY_TYPE
               boolean notOnEdge =
                       (cy > yMin && cy < yMax - 1)
                       && (cx > 0 && cx < 15)
@@ -866,9 +866,7 @@ public class Scene implements JsonSerializable, Refreshable {
                       && palette.get(blocks[Chunk.chunkIndex(cx, cy, cz-1)]).opaque;
 
               if(isHidden) {
-                // Store "whatever" in the octrees
-                Octree.Node whateverNode = new Octree.Node(Octree.ANY_TYPE);
-                worldOctree.set(whateverNode, x, cy - origin.y, z);
+                worldOctree.set(new Octree.Node(Octree.ANY_TYPE), x, cy - origin.y, z);
               } else {
                 Octree.Node octNode = new Octree.Node(blocks[index]);
                 Block block = palette.get(blocks[index]);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -867,7 +867,7 @@ public class Scene implements JsonSerializable, Refreshable {
 
               if(isHidden) {
                 // Store "whatever" in the octrees
-                Octree.Node whateverNode = new Octree.Node(Octree.WHATEVER_TYPE);
+                Octree.Node whateverNode = new Octree.Node(Octree.ANY_TYPE);
                 worldOctree.set(whateverNode, x, cy - origin.y, z);
               } else {
                 Octree.Node octNode = new Octree.Node(blocks[index]);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -929,6 +929,10 @@ public class Scene implements JsonSerializable, Refreshable {
     Set<ChunkPosition> chunkSet = new HashSet<>(chunksToLoad);
 
     try (TaskTracker.Task task = progress.task("Finalizing octree")) {
+
+      worldOctree.startFinalization();
+      waterOctree.startFinalization();
+
       int done = 0;
       int target = chunksToLoad.size();
       for (ChunkPosition cp : chunksToLoad) {
@@ -976,6 +980,9 @@ public class Scene implements JsonSerializable, Refreshable {
         done += 1;
         OctreeFinalizer.finalizeChunk(worldOctree, waterOctree, palette, origin, cp);
       }
+
+      worldOctree.endFinalization();
+      waterOctree.endFinalization();
     }
 
     chunks = loadedChunks;

--- a/chunky/src/java/se/llbit/chunky/world/Chunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/Chunk.java
@@ -18,6 +18,8 @@ package se.llbit.chunky.world;
 
 import se.llbit.chunky.block.Air;
 import se.llbit.chunky.block.Block;
+import se.llbit.chunky.block.Lava;
+import se.llbit.chunky.block.Water;
 import se.llbit.chunky.chunk.BlockPalette;
 import se.llbit.chunky.map.AbstractLayer;
 import se.llbit.chunky.map.BiomeLayer;
@@ -349,6 +351,32 @@ public class Chunk {
         }
       }
     }
+  }
+
+  public static int waterLevelAt(int[] blocks, BlockPalette palette, int cx, int cy, int cz, int baseLevel) {
+    Material corner = palette.get(blocks[chunkIndex(cx, cy, cz)]);
+    if (corner.isWater()) {
+      Material above = palette.get(blocks[Chunk.chunkIndex(cx, cy+1, cz)]);
+      boolean isFullBlock = above.isWaterFilled() || above.solid;
+      return isFullBlock ? 8 : 8 - ((Water) corner).level;
+    } else if (corner.waterlogged) {
+      return 8;
+    } else if (!corner.solid) {
+      return 0;
+    }
+    return baseLevel;
+  }
+
+  public static int lavaLevelAt(int[] blocks, BlockPalette palette, int cx, int cy, int cz, int baseLevel) {
+    Material corner = palette.get(blocks[chunkIndex(cx, cy, cz)]);
+    if (corner instanceof Lava) {
+      Material above = palette.get(blocks[Chunk.chunkIndex(cx, cy+1, cz)]);
+      boolean isFullBlock = above instanceof Lava;
+      return isFullBlock ? 8 : 8 - ((Lava) corner).level;
+    } else if (!corner.solid) {
+      return 0;
+    }
+    return baseLevel;
   }
 
   /**

--- a/chunky/src/java/se/llbit/math/BigPackedOctree.java
+++ b/chunky/src/java/se/llbit/math/BigPackedOctree.java
@@ -468,9 +468,13 @@ public class BigPackedOctree implements Octree.OctreeImplementation {
     for(int i = 0; i < 8; ++i) {
       long childIndex = getAt(nodeIndex) + i;
       if(getAt(childIndex) > 0) {
-        canMerge = false;
         finalizationNode(childIndex);
-      } else if(canMerge) {
+        // The node may have been merged, retest if it still a branch node
+        if(getAt(childIndex) > 0) {
+          canMerge = false;
+        }
+      }
+      if(canMerge) {
         if(mergedType == WHATEVER_TYPE) {
           long value = getAt(childIndex);
           mergedType = typeFromValue(value);

--- a/chunky/src/java/se/llbit/math/BigPackedOctree.java
+++ b/chunky/src/java/se/llbit/math/BigPackedOctree.java
@@ -1,14 +1,7 @@
 package se.llbit.math;
 
-import org.apache.commons.math3.util.FastMath;
-import se.llbit.chunky.block.Air;
-import se.llbit.chunky.block.Block;
 import se.llbit.chunky.block.UnknownBlock;
-import se.llbit.chunky.block.Water;
 import se.llbit.chunky.chunk.BlockPalette;
-import se.llbit.chunky.model.TexturedBlockModel;
-import se.llbit.chunky.model.WaterModel;
-import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.world.Material;
 
 import java.io.DataInputStream;
@@ -17,7 +10,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 
 import static se.llbit.math.Octree.*;
-import static se.llbit.math.Octree.WHATEVER_TYPE;
 
 /**
  * This is a big packed representation of an octree
@@ -463,7 +455,7 @@ public class BigPackedOctree implements Octree.OctreeImplementation {
 
   private void finalizationNode(long nodeIndex) {
     boolean canMerge = true;
-    int mergedType = WHATEVER_TYPE;
+    int mergedType = ANY_TYPE;
     int mergedData = 0;
     for(int i = 0; i < 8; ++i) {
       long childIndex = getAt(nodeIndex) + i;
@@ -475,11 +467,11 @@ public class BigPackedOctree implements Octree.OctreeImplementation {
         }
       }
       if(canMerge) {
-        if(mergedType == WHATEVER_TYPE) {
+        if(mergedType == ANY_TYPE) {
           long value = getAt(childIndex);
           mergedType = typeFromValue(value);
           mergedData = dataFromValue(value);
-        } else if(!(typeFromValue(getAt(childIndex)) == WHATEVER_TYPE || getAt(childIndex) == valueFromTypeData(mergedType, mergedData))) {
+        } else if(!(typeFromValue(getAt(childIndex)) == ANY_TYPE || getAt(childIndex) == valueFromTypeData(mergedType, mergedData))) {
           canMerge = false;
         }
       }

--- a/chunky/src/java/se/llbit/math/BigPackedOctree.java
+++ b/chunky/src/java/se/llbit/math/BigPackedOctree.java
@@ -449,7 +449,7 @@ public class BigPackedOctree implements Octree.OctreeImplementation {
 
   @Override
   public void endFinalization() {
-    // There is a bunch of WHATEVER nodes we should try to merge
+    // There is a bunch of ANY_TYPE nodes we should try to merge
     finalizationNode(0);
   }
 

--- a/chunky/src/java/se/llbit/math/NodeBasedOctree.java
+++ b/chunky/src/java/se/llbit/math/NodeBasedOctree.java
@@ -223,9 +223,13 @@ public class NodeBasedOctree implements Octree.OctreeImplementation {
     for(int i = 0; i < 8; ++i) {
       Octree.Node child = node.children[i];
       if(child.type == BRANCH_NODE) {
-        canMerge = false;
-        finalizationNode(child, node, i);
-      } else if(canMerge) {
+        finalizationNode(child, node, i);// The node may have been merged, retest if it still a branch node
+        child = node.children[i];
+        if(child.type == BRANCH_NODE) {
+          canMerge = false;
+        }
+      }
+      if(canMerge) {
         if(mergedType == WHATEVER_TYPE) {
           mergedType = child.type;
           mergedData = child.getData();

--- a/chunky/src/java/se/llbit/math/NodeBasedOctree.java
+++ b/chunky/src/java/se/llbit/math/NodeBasedOctree.java
@@ -1,22 +1,15 @@
 package se.llbit.math;
 
 import org.apache.commons.math3.util.FastMath;
-import se.llbit.chunky.block.Air;
-import se.llbit.chunky.block.Block;
 import se.llbit.chunky.block.UnknownBlock;
-import se.llbit.chunky.block.Water;
 import se.llbit.chunky.chunk.BlockPalette;
-import se.llbit.chunky.model.TexturedBlockModel;
-import se.llbit.chunky.model.WaterModel;
-import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.world.Material;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 
-import static se.llbit.math.Octree.BRANCH_NODE;
-import static se.llbit.math.Octree.WHATEVER_TYPE;
+import static se.llbit.math.Octree.*;
 
 /**
  * This is the classic node-based implementation of an octree
@@ -218,7 +211,7 @@ public class NodeBasedOctree implements Octree.OctreeImplementation {
 
   private void finalizationNode(Octree.Node node, Octree.Node parent, int childNo) {
     boolean canMerge = true;
-    int mergedType = WHATEVER_TYPE;
+    int mergedType = ANY_TYPE;
     int mergedData = 0;
     for(int i = 0; i < 8; ++i) {
       Octree.Node child = node.children[i];
@@ -230,10 +223,10 @@ public class NodeBasedOctree implements Octree.OctreeImplementation {
         }
       }
       if(canMerge) {
-        if(mergedType == WHATEVER_TYPE) {
+        if(mergedType == ANY_TYPE) {
           mergedType = child.type;
           mergedData = child.getData();
-        } else if(!(child.type == WHATEVER_TYPE || (child.type == mergedType && child.getData() == mergedData))) {
+        } else if(!(child.type == ANY_TYPE || (child.type == mergedType && child.getData() == mergedData))) {
           canMerge = false;
         }
       }

--- a/chunky/src/java/se/llbit/math/NodeBasedOctree.java
+++ b/chunky/src/java/se/llbit/math/NodeBasedOctree.java
@@ -205,7 +205,7 @@ public class NodeBasedOctree implements Octree.OctreeImplementation {
 
   @Override
   public void endFinalization() {
-    // There is a bunch of WHATEVER nodes we should try to merge
+    // There is a bunch of ANY_TYPE nodes we should try to merge
     finalizationNode(root, null, 0);
   }
 

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -687,14 +687,11 @@ public class Octree {
   }
 
   public void startFinalization() {
-    System.out.printf("%d nodes before finalization\n", implementation.nodeCount()); // TODO Remove
     implementation.startFinalization();
   }
 
   public void endFinalization() {
-    System.out.printf("%d nodes before end of finalization\n", implementation.nodeCount()); // TODO Remove
     implementation.endFinalization();
-    System.out.printf("%d nodes after finalization\n", implementation.nodeCount()); // TODO Remove
   }
 
   /**

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -692,6 +692,7 @@ public class Octree {
   }
 
   public void endFinalization() {
+    System.out.printf("%d nodes before end of finalization\n", implementation.nodeCount()); // TODO Remove
     implementation.endFinalization();
     System.out.printf("%d nodes after finalization\n", implementation.nodeCount()); // TODO Remove
   }

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -687,11 +687,13 @@ public class Octree {
   }
 
   public void startFinalization() {
+    System.out.printf("%d nodes before finalization\n", implementation.nodeCount()); // TODO Remove
     implementation.startFinalization();
   }
 
   public void endFinalization() {
     implementation.endFinalization();
+    System.out.printf("%d nodes after finalization\n", implementation.nodeCount()); // TODO Remove
   }
 
   /**

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -52,6 +52,8 @@ public class Octree {
     NodeId getChild(NodeId parent, int childNo);
     int getType(NodeId node);
     int getData(NodeId node);
+    default void startFinalization() {}
+    default void endFinalization() {}
   }
 
   public interface NodeId {}
@@ -682,6 +684,14 @@ public class Octree {
 
   public int getDepth() {
     return implementation.getDepth();
+  }
+
+  public void startFinalization() {
+    implementation.startFinalization();
+  }
+
+  public void endFinalization() {
+    implementation.endFinalization();
   }
 
   /**

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -76,6 +76,13 @@ public class Octree {
   public static final int BRANCH_NODE = -1;
 
   /**
+   * A special type that indicate that we don't care about nodes with this type
+   * (The value is chosen to behave like a normal type i.e first bit not set
+   * and so that when serialized with data, it is not confused for a branch node)
+   */
+  public static final int WHATEVER_TYPE = 0x7FFFFFFE;
+
+  /**
    * The top bit of the type field in a serialized octree node is reserved for indicating
    * if the node is a data node.
    */

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -82,7 +82,7 @@ public class Octree {
    * (The value is chosen to behave like a normal type i.e first bit not set
    * and so that when serialized with data, it is not confused for a branch node)
    */
-  public static final int WHATEVER_TYPE = 0x7FFFFFFE;
+  public static final int ANY_TYPE = 0x7FFFFFFE;
 
   /**
    * The top bit of the type field in a serialized octree node is reserved for indicating

--- a/chunky/src/java/se/llbit/math/PackedOctree.java
+++ b/chunky/src/java/se/llbit/math/PackedOctree.java
@@ -438,7 +438,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
 
   private void finalizationNode(int nodeIndex) {
     boolean canMerge = true;
-    int mergedType = WHATEVER_TYPE;
+    int mergedType = -WHATEVER_TYPE;
     int mergedData = 0;
     for(int i = 0; i < 8; ++i) {
       int childIndex = treeData[nodeIndex] + 2 * i;
@@ -450,10 +450,10 @@ public class PackedOctree implements Octree.OctreeImplementation {
         }
       }
       if(canMerge) {
-        if(mergedType == WHATEVER_TYPE) {
+        if(mergedType == -WHATEVER_TYPE) {
           mergedType = treeData[childIndex];
           mergedData = treeData[childIndex + 1];
-        } else if(!(treeData[childIndex] == WHATEVER_TYPE || (treeData[childIndex] == mergedType && treeData[childIndex + 1] == mergedData))) {
+        } else if(!(treeData[childIndex] == -WHATEVER_TYPE || (treeData[childIndex] == mergedType && treeData[childIndex + 1] == mergedData))) {
           canMerge = false;
         }
       }

--- a/chunky/src/java/se/llbit/math/PackedOctree.java
+++ b/chunky/src/java/se/llbit/math/PackedOctree.java
@@ -1,14 +1,7 @@
 package se.llbit.math;
 
-import org.apache.commons.math3.util.FastMath;
-import se.llbit.chunky.block.Air;
-import se.llbit.chunky.block.Block;
 import se.llbit.chunky.block.UnknownBlock;
-import se.llbit.chunky.block.Water;
 import se.llbit.chunky.chunk.BlockPalette;
-import se.llbit.chunky.model.TexturedBlockModel;
-import se.llbit.chunky.model.WaterModel;
-import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.world.Material;
 
 import java.io.DataInputStream;
@@ -438,7 +431,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
 
   private void finalizationNode(int nodeIndex) {
     boolean canMerge = true;
-    int mergedType = -WHATEVER_TYPE;
+    int mergedType = -ANY_TYPE;
     int mergedData = 0;
     for(int i = 0; i < 8; ++i) {
       int childIndex = treeData[nodeIndex] + 2 * i;
@@ -450,10 +443,10 @@ public class PackedOctree implements Octree.OctreeImplementation {
         }
       }
       if(canMerge) {
-        if(mergedType == -WHATEVER_TYPE) {
+        if(mergedType == -ANY_TYPE) {
           mergedType = treeData[childIndex];
           mergedData = treeData[childIndex + 1];
-        } else if(!(treeData[childIndex] == -WHATEVER_TYPE || (treeData[childIndex] == mergedType && treeData[childIndex + 1] == mergedData))) {
+        } else if(!(treeData[childIndex] == -ANY_TYPE || (treeData[childIndex] == mergedType && treeData[childIndex + 1] == mergedData))) {
           canMerge = false;
         }
       }

--- a/chunky/src/java/se/llbit/math/PackedOctree.java
+++ b/chunky/src/java/se/llbit/math/PackedOctree.java
@@ -15,8 +15,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 
-import static se.llbit.math.Octree.BRANCH_NODE;
-import static se.llbit.math.Octree.DATA_FLAG;
+import static se.llbit.math.Octree.*;
 
 /**
  * This is a packed representation of an octree
@@ -26,29 +25,29 @@ import static se.llbit.math.Octree.DATA_FLAG;
 public class PackedOctree implements Octree.OctreeImplementation {
   /**
    * The whole tree data is store in a int array
-   *
+   * <p>
    * Each node is made of several values :
-   *  - the node type (could be a branch node or the type of block contained)
-   *  - optional additional data
-   *  - the index of its first child (if branch node)
-   *
-   *  As nodes are stored linearly, we place siblings nodes in a row and so
-   *  we only need the index of the first child as the following are just after
-   *
-   *  The node type is always positive, we can use this knowledge to compress the node to 2 ints:
-   *  one will contains the index of the first child if it is positive or the negation of the type
-   *  the other will contain the additional data
-   *
-   *  This implementation is inspired by this stackoverflow answer
-   *  https://stackoverflow.com/questions/41946007/efficient-and-well-explained-implementation-of-a-quadtree-for-2d-collision-det#answer-48330314
-   *
-   *  Note: Only leaf nodes can have additional data. In theory
-   *  we could potentially optimize further by only storing the index for branch nodes
-   *  by that would make other operations more complex. Most likely not worth it but could be an idea
-   *
-   *  When dealing with huge octree, the maximum size of an array may be a limitation
-   *  When this occurs this implementation wan no longer be used and we must fallback on another one.
-   *  Here we'll throw an exception that the caller can catch
+   * - the node type (could be a branch node or the type of block contained)
+   * - optional additional data
+   * - the index of its first child (if branch node)
+   * <p>
+   * As nodes are stored linearly, we place siblings nodes in a row and so
+   * we only need the index of the first child as the following are just after
+   * <p>
+   * The node type is always positive, we can use this knowledge to compress the node to 2 ints:
+   * one will contains the index of the first child if it is positive or the negation of the type
+   * the other will contain the additional data
+   * <p>
+   * This implementation is inspired by this stackoverflow answer
+   * https://stackoverflow.com/questions/41946007/efficient-and-well-explained-implementation-of-a-quadtree-for-2d-collision-det#answer-48330314
+   * <p>
+   * Note: Only leaf nodes can have additional data. In theory
+   * we could potentially optimize further by only storing the index for branch nodes
+   * by that would make other operations more complex. Most likely not worth it but could be an idea
+   * <p>
+   * When dealing with huge octree, the maximum size of an array may be a limitation
+   * When this occurs this implementation wan no longer be used and we must fallback on another one.
+   * Here we'll throw an exception that the caller can catch
    */
   private int[] treeData;
 
@@ -91,22 +90,22 @@ public class PackedOctree implements Octree.OctreeImplementation {
 
   @Override
   public boolean isBranch(Octree.NodeId node) {
-    return treeData[((NodeId)node).nodeIndex] > 0;
+    return treeData[((NodeId) node).nodeIndex] > 0;
   }
 
   @Override
   public Octree.NodeId getChild(Octree.NodeId parent, int childNo) {
-    return new NodeId(treeData[((NodeId)parent).nodeIndex] + 2*childNo);
+    return new NodeId(treeData[((NodeId) parent).nodeIndex] + 2 * childNo);
   }
 
   @Override
   public int getType(Octree.NodeId node) {
-    return -treeData[((NodeId)node).nodeIndex];
+    return -treeData[((NodeId) node).nodeIndex];
   }
 
   @Override
   public int getData(Octree.NodeId node) {
-    return treeData[((NodeId)node).nodeIndex+1];
+    return treeData[((NodeId) node).nodeIndex + 1];
   }
 
   /**
@@ -117,15 +116,16 @@ public class PackedOctree implements Octree.OctreeImplementation {
 
   /**
    * Constructor building a tree with capacity for some nodes
-   * @param depth The depth of the tree
+   *
+   * @param depth     The depth of the tree
    * @param nodeCount The number of nodes this tree will contain
    */
   public PackedOctree(int depth, long nodeCount) {
     this.depth = depth;
-    long arraySize = Math.max(nodeCount*2, 64);
-    if(arraySize > (long)MAX_ARRAY_SIZE)
+    long arraySize = Math.max(nodeCount * 2, 64);
+    if(arraySize > (long) MAX_ARRAY_SIZE)
       throw new OctreeTooBigException();
-    treeData = new int[(int)arraySize];
+    treeData = new int[(int) arraySize];
     treeData[0] = 0;
     treeData[1] = 0;
     size = 2;
@@ -134,6 +134,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
 
   /**
    * Constructs an empty octree
+   *
    * @param depth The depth of the tree
    */
   public PackedOctree(int depth) {
@@ -151,6 +152,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
    * We find space by searching in the free list
    * if this fails we append at the end of the array
    * if the size is greater than the capacity, we allocate a new array
+   *
    * @return the index at the beginning of a free space in the array of size 16 ints (8 nodes)
    */
   private int findSpace() {
@@ -162,16 +164,16 @@ public class PackedOctree implements Octree.OctreeImplementation {
     }
 
     // append in array if we have the capacity
-    if(size+16 <= treeData.length) {
+    if(size + 16 <= treeData.length) {
       int index = size;
       size += 16;
       return index;
     }
 
     // We need to grow the array
-    long newSize = (long)Math.ceil(treeData.length*1.5);
+    long newSize = (long) Math.ceil(treeData.length * 1.5);
     // We need to check the array won't be too big
-    if(newSize > (long)MAX_ARRAY_SIZE) {
+    if(newSize > (long) MAX_ARRAY_SIZE) {
       // We can allocate less memory than initially wanted if the next block will still be able to fit
       // If not, this implementation isn't suitable
       if(MAX_ARRAY_SIZE - treeData.length > 16) {
@@ -182,7 +184,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
         throw new OctreeTooBigException();
       }
     }
-    int[] newArray = new int[(int)newSize];
+    int[] newArray = new int[(int) newSize];
     System.arraycopy(treeData, 0, newArray, 0, size);
     treeData = newArray;
     // and then append
@@ -194,6 +196,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
 
   /**
    * free space at the given index, simply add the 16 ints block beginning at index to the free list
+   *
    * @param index the index of the beginning of the block to free
    */
   private void freeSpace(int index) {
@@ -203,33 +206,36 @@ public class PackedOctree implements Octree.OctreeImplementation {
 
   /**
    * Subdivide a node, give to each child the same type and data that this node previously had
+   *
    * @param nodeIndex The index of the node to subdivide
    */
   private void subdivideNode(int nodeIndex) {
     int childrenIndex = findSpace();
     for(int i = 0; i < 8; ++i) {
-      treeData[childrenIndex + 2*i] = treeData[nodeIndex]; // copy type
-      treeData[childrenIndex + 2*i + 1] = treeData[nodeIndex+1]; // copy data
+      treeData[childrenIndex + 2 * i] = treeData[nodeIndex]; // copy type
+      treeData[childrenIndex + 2 * i + 1] = treeData[nodeIndex + 1]; // copy data
     }
     treeData[nodeIndex] = childrenIndex; // Make the node a parent node pointing to its children
-    treeData[nodeIndex+1] = 0; // reset its data
+    treeData[nodeIndex + 1] = 0; // reset its data
   }
 
   /**
    * Merge a parent node so it becomes a leaf node
-   * @param nodeIndex The index of the node to merge
+   *
+   * @param nodeIndex    The index of the node to merge
    * @param typeNegation The negation of the type (the value directly stored in the array)
    */
   private void mergeNode(int nodeIndex, int typeNegation, int data) {
     int childrenIndex = treeData[nodeIndex];
     freeSpace(childrenIndex); // Delete children
     treeData[nodeIndex] = typeNegation; // Make the node a leaf one
-    treeData[nodeIndex+1] = data;
+    treeData[nodeIndex + 1] = data;
   }
 
   /**
    * Compare two nodes
-   * @param firstNodeIndex The index of the first node
+   *
+   * @param firstNodeIndex  The index of the first node
    * @param secondNodeIndex The index of the second node
    * @return true id the nodes compare equals, false otherwise
    */
@@ -237,7 +243,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
     boolean firstIsBranch = treeData[firstNodeIndex] > 0;
     boolean secondIsBranch = treeData[secondNodeIndex] > 0;
     return ((firstIsBranch && secondIsBranch) || treeData[firstNodeIndex] == treeData[secondNodeIndex]) // compare types
-      && treeData[firstNodeIndex+1] == treeData[secondNodeIndex+1]; // compare data
+            && treeData[firstNodeIndex + 1] == treeData[secondNodeIndex + 1]; // compare data
     // FIXME possible bug here as we always compare the data even when dealing with nodes that don't really have data
     // The data int could potentially contain some junk leftover of a previous node
     // In theory it should be reset to 0 but we need to be careful
@@ -245,15 +251,16 @@ public class PackedOctree implements Octree.OctreeImplementation {
 
   /**
    * Compare two nodes
+   *
    * @param firstNodeIndex The index of the first node
-   * @param secondNode The second node (most likely outside of tree)
+   * @param secondNode     The second node (most likely outside of tree)
    * @return true id the nodes compare equals, false otherwise
    */
   private boolean nodeEquals(int firstNodeIndex, Octree.Node secondNode) {
     boolean firstIsBranch = treeData[firstNodeIndex] > 0;
     boolean secondIsBranch = (secondNode.type == BRANCH_NODE);
     return ((firstIsBranch && secondIsBranch) || -treeData[firstNodeIndex] == secondNode.type) // compare types (don't forget that in the tree the negation of the type is stored)
-            && treeData[firstNodeIndex+1] == secondNode.getData(); // compare data
+            && treeData[firstNodeIndex + 1] == secondNode.getData(); // compare data
   }
 
   @Override
@@ -267,12 +274,12 @@ public class PackedOctree implements Octree.OctreeImplementation {
     int nodeIndex = 0;
     int parentLevel = depth - 1;
     int position = 0;
-    for (int i = depth - 1; i >= 0; --i) {
+    for(int i = depth - 1; i >= 0; --i) {
       parents[i] = nodeIndex;
 
-      if (nodeEquals(nodeIndex, data)) {
+      if(nodeEquals(nodeIndex, data)) {
         return;
-      } else if (treeData[nodeIndex] <= 0) { // It's a leaf node
+      } else if(treeData[nodeIndex] <= 0) { // It's a leaf node
         subdivideNode(nodeIndex);
         parentLevel = i;
       }
@@ -281,28 +288,28 @@ public class PackedOctree implements Octree.OctreeImplementation {
       int ybit = 1 & (y >> i);
       int zbit = 1 & (z >> i);
       position = (xbit << 2) | (ybit << 1) | zbit;
-      nodeIndex = treeData[nodeIndex] + position*2;
+      nodeIndex = treeData[nodeIndex] + position * 2;
 
     }
-    int finalNodeIndex = treeData[parents[0]] + position*2;
+    int finalNodeIndex = treeData[parents[0]] + position * 2;
     treeData[finalNodeIndex] = -data.type; // Store negation of the type
-    treeData[finalNodeIndex+1] = data.getData();
+    treeData[finalNodeIndex + 1] = data.getData();
 
     // Merge nodes where all children have been set to the same type.
-    for (int i = 0; i <= parentLevel; ++i) {
+    for(int i = 0; i <= parentLevel; ++i) {
       int parentIndex = parents[i];
 
       boolean allSame = true;
       for(int j = 0; j < 8; ++j) {
-        int childIndex = treeData[parentIndex] + 2*j;
+        int childIndex = treeData[parentIndex] + 2 * j;
         if(!nodeEquals(childIndex, nodeIndex)) {
           allSame = false;
           break;
         }
       }
 
-      if (allSame) {
-        mergeNode(parentIndex, treeData[nodeIndex], treeData[nodeIndex+1]);
+      if(allSame) {
+        mergeNode(parentIndex, treeData[nodeIndex], treeData[nodeIndex + 1]);
       } else {
         break;
       }
@@ -326,7 +333,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
   public Octree.Node get(int x, int y, int z) {
     int nodeIndex = getNodeIndex(x, y, z);
 
-    Octree.Node node = new Octree.DataNode(treeData[nodeIndex] > 0 ? BRANCH_NODE : -treeData[nodeIndex], treeData[nodeIndex+1]);
+    Octree.Node node = new Octree.DataNode(treeData[nodeIndex] > 0 ? BRANCH_NODE : -treeData[nodeIndex], treeData[nodeIndex + 1]);
 
     // Return dummy Node, will work if only type and data are used, breaks if children are needed
     return node;
@@ -372,18 +379,18 @@ public class PackedOctree implements Octree.OctreeImplementation {
     if(type == BRANCH_NODE) {
       int childrenIndex = findSpace();
       treeData[nodeIndex] = childrenIndex;
-      treeData[nodeIndex+1] = 0; // store 0 as data
-      for (int i = 0; i < 8; ++i) {
-        loadNode(in, childrenIndex + 2*i);
+      treeData[nodeIndex + 1] = 0; // store 0 as data
+      for(int i = 0; i < 8; ++i) {
+        loadNode(in, childrenIndex + 2 * i);
       }
     } else {
-      if ((type & DATA_FLAG) == 0) {
+      if((type & DATA_FLAG) == 0) {
         treeData[nodeIndex] = -type; // negation of type
-        treeData[nodeIndex+1] = 0; // store 0 to be sure we don't have uninitialized garbage
+        treeData[nodeIndex + 1] = 0; // store 0 to be sure we don't have uninitialized garbage
       } else {
         int data = in.readInt();
         treeData[nodeIndex] = -(type ^ DATA_FLAG);
-        treeData[nodeIndex+1] = data;
+        treeData[nodeIndex + 1] = data;
       }
     }
   }
@@ -393,14 +400,14 @@ public class PackedOctree implements Octree.OctreeImplementation {
     if(type == BRANCH_NODE) {
       out.writeInt(type);
       for(int i = 0; i < 8; ++i) {
-        int childIndex = treeData[nodeIndex] + 2*i;
+        int childIndex = treeData[nodeIndex] + 2 * i;
         storeNode(out, childIndex);
       }
     } else {
-      boolean isDataNode = (treeData[nodeIndex+1] != 0);
+      boolean isDataNode = (treeData[nodeIndex + 1] != 0);
       if(isDataNode) {
         out.writeInt(type | DATA_FLAG);
-        out.writeInt(treeData[nodeIndex+1]);
+        out.writeInt(treeData[nodeIndex + 1]);
       } else {
         out.writeInt(type);
       }
@@ -416,10 +423,39 @@ public class PackedOctree implements Octree.OctreeImplementation {
     if(treeData[nodeIndex] > 0) {
       long total = 1;
       for(int i = 0; i < 8; ++i)
-        total += countNodes(treeData[nodeIndex] + 2*i);
+        total += countNodes(treeData[nodeIndex] + 2 * i);
       return total;
     } else {
       return 1;
+    }
+  }
+
+  @Override
+  public void endFinalization() {
+    // There is a bunch of WHATEVER nodes we should try to merge
+    finalizationNode(0);
+  }
+
+  private void finalizationNode(int nodeIndex) {
+    boolean canMerge = true;
+    int mergedType = WHATEVER_TYPE;
+    int mergedData = 0;
+    for(int i = 0; i < 8; ++i) {
+      int childIndex = treeData[nodeIndex] + 2 * i;
+      if(treeData[childIndex] > 0) {
+        canMerge = false;
+        finalizationNode(childIndex);
+      } else if(canMerge) {
+        if(mergedType == WHATEVER_TYPE) {
+          mergedType = treeData[childIndex];
+          mergedData = treeData[childIndex + 1];
+        } else if(!(treeData[childIndex] == WHATEVER_TYPE || (treeData[childIndex] == mergedType && treeData[childIndex + 1] == mergedData))) {
+          canMerge = false;
+        }
+      }
+    }
+    if(canMerge) {
+      mergeNode(nodeIndex, mergedType, mergedData);
     }
   }
 

--- a/chunky/src/java/se/llbit/math/PackedOctree.java
+++ b/chunky/src/java/se/llbit/math/PackedOctree.java
@@ -443,9 +443,13 @@ public class PackedOctree implements Octree.OctreeImplementation {
     for(int i = 0; i < 8; ++i) {
       int childIndex = treeData[nodeIndex] + 2 * i;
       if(treeData[childIndex] > 0) {
-        canMerge = false;
         finalizationNode(childIndex);
-      } else if(canMerge) {
+        // The node may have been merged, retest if it still a branch node
+        if(treeData[childIndex] > 0) {
+          canMerge = false;
+        }
+      }
+      if(canMerge) {
         if(mergedType == WHATEVER_TYPE) {
           mergedType = treeData[childIndex];
           mergedData = treeData[childIndex + 1];

--- a/chunky/src/java/se/llbit/math/PackedOctree.java
+++ b/chunky/src/java/se/llbit/math/PackedOctree.java
@@ -425,7 +425,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
 
   @Override
   public void endFinalization() {
-    // There is a bunch of WHATEVER nodes we should try to merge
+    // There is a bunch of ANY_TYPE nodes we should try to merge
     finalizationNode(0);
   }
 


### PR DESCRIPTION
Related to #633 
Finalizing the octree is slow, especially when dealing with very large scene, because for each block we need to take action depending on its neighboring blocks, this means walking down the octree up to 10 times for each block. Walking down the octree is cheap but not free so, given the number of blocks this ends up costing a lot of time.
The idea of this PR is to do some of the computation requiring neighboring blocks when loading a chunk, when accessing blocks is cheaper as they are directly stored in a flat array. Blocks that are on the edge of a chunk don't have all of their neighbors available so those are still processed in the finalization phase as before.
While implementing this i also added the "whatever" type i suggested on discord that helps merging nodes more efficiently and added hook for octree implementation to be notified of when finalization takes place.

I did some measurement to compare the loading time before and after this PR. I loaded a 4k chunks scene three times without closing chunky in-between
Results:
|     | Loading time | Finalizing time | Total time |
|------|---------------|--------------------|---------------|
| Before, run 1 | 35s | 43s | 78s |
| Before, run 2 | 37s | 39s | 76s |
| Before, run 3 | 38s | 39s | 77s |
| **Before, average** | **37s** | **40s** | **77s** |
| After, run 1 | 27s | 7s | 34s |
| After, run 2 | 75s | 9s | 84s |
| After, run 3 | 39s | 9s | 48s |
| **After, average** | **46s** | **8s** | **55s** |

Results to take with a grain of salt, the variance for the after is huge (during the second run my computer froze for a bit, most likely due to swapping).

I would appreciate if someone with more memory could make some bigger scale tests