### PR TITLE
Fix previous scene directory being used after creating a new scene from a selection

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -341,7 +341,7 @@ public class Scene implements JsonSerializable, Refreshable {
    */
   public static void exportToZip(String name, File targetFile) {
     String[] extensions = { ".json", ".dump", ".octree2", ".foliage", ".grass", };
-    ZipExport.zip(targetFile, PersistentSettings.getSceneDirectory(), name, extensions);
+    ZipExport.zip(targetFile, SynchronousSceneManager.resolveSceneDirectory(name), name, extensions);
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/SynchronousSceneManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/SynchronousSceneManager.java
@@ -160,9 +160,9 @@ public class SynchronousSceneManager implements SceneProvider, SceneManager {
   @Override public void loadFreshChunks(World world, Collection<ChunkPosition> chunksToLoad) {
     synchronized (scene) {
       scene.clear();
-      context.setSceneDirectory(resolveSceneDirectory(scene.name));
       scene.loadChunks(taskTracker, world, chunksToLoad);
       scene.resetScene(null, context.getChunky().getSceneFactory());
+      context.setSceneDirectory(resolveSceneDirectory(scene.name));
       scene.refresh();
       scene.setResetReason(ResetReason.SCENE_LOADED);
       scene.setRenderMode(RenderMode.PREVIEW);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/SynchronousSceneManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/SynchronousSceneManager.java
@@ -302,7 +302,7 @@ public class SynchronousSceneManager implements SceneProvider, SceneManager {
    * @param sceneName The name of the scene to resolve the directory for.
    * @return The directory holding the given scene
    */
-  private File resolveSceneDirectory(String sceneName) {
+  public static File resolveSceneDirectory(String sceneName) {
     File defaultDirectory = new File(PersistentSettings.getSceneDirectory(), sceneName);
 
     if (!defaultDirectory.exists()) {


### PR DESCRIPTION
Resetting a scene and providing `null` as new name will generate a new name so the scene directory needs to be set _after_ that.

Re https://github.com/llbit/chunky/issues/639#issuecomment-660552895