### PR TITLE
Add a new optional method to OctreeImplementation interface

### DIFF
--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -587,6 +587,10 @@ public class Octree {
       NodeId node = nodeAndLevel.getFirst();
       int level = nodeAndLevel.getSecond();
 
+      lx = x >>> level;
+      ly = y >>> level;
+      lz = z >>> level;
+
       // Test intersection
       Block currentBlock = palette.get(implementation.getType(node));
       Material prevBlock = ray.getCurrentMaterial();


### PR DESCRIPTION
This PR adds a new method to octree implementation interface (with a default implementation) that is used in `enterBlock` and `exitWater`. Functionally it changes nothing but it allow octree implementations to implement a different version (more efficient for example, i have an use case for that)