### PR TITLE
Underwater fog

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -113,7 +113,7 @@ public class PathTracer implements RayTracer {
       float n1 = prevMat.ior;
       float n2 = currentMat.ior;
 
-      if (prevMat == Air.INSTANCE) {
+      if (prevMat == Air.INSTANCE || prevMat.isWater()) {
         airDistance = ray.distance;
       }
 

--- a/chunky/src/java/se/llbit/chunky/ui/render/SkyTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/SkyTab.java
@@ -104,6 +104,7 @@ public class SkyTab extends ScrollPane implements RenderControlsTab, Initializab
     fogDensity.setTooltip("Fog thickness. Set to 0 to disable volumetric fog effect.");
     fogDensity.setRange(0, 2);
     fogDensity.clampMin();
+    fogDensity.makeLogarithmic();
     fogDensity.onValueChange(value -> scene.setFogDensity(value));
 
     skyFogDensity.setTooltip(


### PR DESCRIPTION
The underwater emitter fix removed the possibility to have underwater fog.
It seemed underwater fog was not supposed to be but was a consequence of a bug. I made underwater fog work by taking into consideration distance traveled underwater the same as distance traveled in the air. If it is deemed to be preferable, we could add a separate configuration for underwater fog and have separate fogs.
I also made the fog slider logarithmic  