### PR TITLE
Fix cloud deadlock bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://material-ui.com/" rel="noopener" target="_blank"><img width="100" src="https://raw.githubusercontent.com/llbit/chunky-docs/master/images/logo.png" alt="Chunky logo"></a>
+  <a href="http://chunky.llbit.se" rel="noopener" target="_blank"><img width="100" src="https://raw.githubusercontent.com/llbit/chunky-docs/master/images/logo.png" alt="Chunky logo"></a>
 </p>
 <h1 align="center">Chunky</h1>
 <div align="center">
@@ -139,11 +139,9 @@ rendering tips are available at the [Chunky Documentation page][1]. For more ins
 
 ## Hacking on Chunky
 
-To build Chunky, run the `gradlew` script in the project root directory:
+To build Chunky, run the `gradlew` script in the project root directory: `./gradlew jar`
 
-   ./gradlew jar
-
-This just builds the core libraries. To build an installable file takes
+This just builds the core libraries. Building an installable file takes
 a bit more work; [refer to this repository][7].
 
 Chunky is split into four subprojects:

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
@@ -939,6 +939,10 @@ public class Sky implements JsonSerializable {
       if (t > tExit) {
         return false;
       }
+      if (nx == 0 && ny == 0 && nz == 0) {
+        // fix ray.n being set to zero (issue #643)
+        return false;
+      }
       ray.n.set(nx, ny, nz);
       enterCloud(ray, t + t_offset);
       return true;


### PR DESCRIPTION
This fixes #643 

:information_source: [I made a debug `Vector3` implementation][1] that validates the vector after every change and throws exceptions if a component becomes `NaN` or if the length is 0 (only for `DebugVector3.NonZero`. This might be helpful for debugging similar bugs in the future because we get stacktraces without printf-style debugging even if we can't reproduce the bugs on our own machines.

[1]: https://github.com/leMaik/chunky/commit/cce8e22d2afda58eab8fdae1a933ffda4e1e7aac