### PR TITLE
Fix chunks not being loaded if the entities or tile entities tags are missing

### DIFF
--- a/chunky/src/java/se/llbit/chunky/world/Chunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/Chunk.java
@@ -428,18 +428,22 @@ public class Chunk {
     if (biomesTag.isByteArray(X_MAX * Z_MAX) || biomesTag.isIntArray(X_MAX * Z_MAX)) {
       extractBiomeData(biomesTag, biomes);
     }
-    if (sections.isList() && tileEntitiesTag.isList()
-        && entitiesTag.isList()) {
+
+    if (sections.isList()) {
       loadBlockData(data, blocks, blockPalette);
-      ListTag list = (ListTag) entitiesTag;
-      for (SpecificTag tag : list) {
-        if (tag.isCompoundTag())
-          entities.add((CompoundTag) tag);
+
+      if (entitiesTag.isList()) {
+        for (SpecificTag tag : (ListTag) entitiesTag) {
+          if (tag.isCompoundTag())
+            entities.add((CompoundTag) tag);
+        }
       }
-      list = (ListTag) tileEntitiesTag;
-      for (SpecificTag tag : list) {
-        if (tag.isCompoundTag())
-          tileEntities.add((CompoundTag) tag);
+
+      if (tileEntitiesTag.isList()) {
+        for (SpecificTag tag : (ListTag) tileEntitiesTag) {
+          if (tag.isCompoundTag())
+            tileEntities.add((CompoundTag) tag);
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #648.

Seems like tile entities are somehow missing in the affected chunks after conversion of <1.13 worlds to 1.13+ world format. Maybe that tag doesn't get converted if there are no tile entities in the chunk to speed up the "optimisation" process. Some chunks can be loaded and it seems that these are chunks that contain tile entities (e.g. chests) and thus contain the tile entities tag.