### PR TITLE
Fix water blocks having full height if any solid block is above it.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -888,7 +888,7 @@ public class Scene implements JsonSerializable, Refreshable {
                   if (cy + 1 < yMax) {
                     int above = Chunk.chunkIndex(cx, cy + 1, cz);
                     Block aboveBlock = palette.get(blocks[above]);
-                    if (aboveBlock.isWaterFilled() || aboveBlock.solid) {
+                    if (aboveBlock.isWaterFilled()) {
                       waterNode = new Octree.DataNode(palette.waterId, 1 << Water.FULL_BLOCK);
                     }
                   }

--- a/chunky/src/java/se/llbit/chunky/world/Chunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/Chunk.java
@@ -357,7 +357,7 @@ public class Chunk {
     Material corner = palette.get(blocks[chunkIndex(cx, cy, cz)]);
     if (corner.isWater()) {
       Material above = palette.get(blocks[Chunk.chunkIndex(cx, cy+1, cz)]);
-      boolean isFullBlock = above.isWaterFilled() || above.solid;
+      boolean isFullBlock = above.isWaterFilled();
       return isFullBlock ? 8 : 8 - ((Water) corner).level;
     } else if (corner.waterlogged) {
       return 8;


### PR DESCRIPTION
Until now, Chunky made water blocks full-height if there was either a water-filled block or a solid block above it. #619 already fixed water rendering below vines by marking them as non-solid (which was correct because vines aren't solid), but it turns out that it doesn't matter if the block is solid: water never has full height if there's is no water-filled block above it.

Before:
![image](https://user-images.githubusercontent.com/5544859/88485214-88699c00-cf74-11ea-9d0e-1fcad1321135.png)

After:
![image](https://user-images.githubusercontent.com/5544859/88485151-23ae4180-cf74-11ea-9ed9-108d2cb0a6ff.png)
