### PR TITLE
Fix cloud deadlock bug part 2 (#647)

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
@@ -956,6 +956,10 @@ public class Sky implements JsonSerializable {
         nx = -nx;
         nz = -nz;
       }
+      if (nx == 0 && ny == 0 && nz == 0) {
+        // fix ray.n being set to zero (issue #643)
+        return false;
+      }
       ray.n.set(nx, ny, nz);
       exitCloud(ray, t);
     }


### PR DESCRIPTION
This is the other location that ray.n can be set to zero. Seems to be rarer than the previous case which might be why I missed it during testing.

Credits to leMaik for finding this.